### PR TITLE
use git submodule instead of git clone when install

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The Images links on [Docker Hub](https://hub.docker.com/u/laradock/)
 1 - Clone the `LaraDock` repository, in any of your `Laravel` projects *(using this command)*:
 
 ```bash
-git clone https://github.com/LaraDock/laradock.git docker
+git submodule add https://github.com/LaraDock/laradock.git docker
 ```
 
 >This should create a `docker` folder, on the root directory of your Laravel project.


### PR DESCRIPTION
I think we should to use `git submodule` here, because if I use `git clone `, and add `docker` folder to my project git repo, when my teammate pulls from  remote, he will faced the `No submodule mapping found in .gitmodules for path 'docker'` error.
