### PR TITLE
install pdo_pgsql extension

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,9 +5,12 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 ADD ./laravel.ini /usr/local/etc/php/conf.d
 ADD ./laravel.pool.conf /usr/local/etc/php-fpm.d/
 
+RUN apt-get update && apt-get install libpq-dev -y
+
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
-    pdo_mysql
+    pdo_mysql \
+    pdo_pgsql
 
 RUN usermod -u 1000 www-data
 


### PR DESCRIPTION
Updates the PHP Dockerfile to install the `pdo_pgsql` extension so the using a Postgres database works out of the box (#34). 

Package `libpq-dev` “provides the header files and static library for compiling C programs to communicate with a PostgreSQL database backend.”