### PR TITLE
Memcached support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
             - /var/lib/postgres
             - /var/lib/mariadb
             - /var/lib/redis
+            - /var/lib/memcached
 
 ### MySQL Container #########################################
 
@@ -107,5 +108,14 @@ services:
             - "2080:2080"
         links:
             - beanstalkd
+
+### Memcached Container #########################################
+
+    memcached:
+        build: ./memcached
+        volumes_from:
+            - data
+        ports:
+            - "11211:11211"
 
 ### Add more Containers below ###############################

--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -1,0 +1,7 @@
+FROM memcached:latest
+
+MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
+
+CMD ["memcached"]
+
+EXPOSE 11211

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,12 +5,22 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 ADD ./laravel.ini /usr/local/etc/php/conf.d
 ADD ./laravel.pool.conf /usr/local/etc/php-fpm.d/
 
-RUN apt-get update && apt-get install libpq-dev -y
+RUN apt-get update && apt-get install libpq-dev -y \
+    curl \
+    libmemcached-dev
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
     pdo_mysql \
     pdo_pgsql
+
+#Installing memcached for php 7 is a bit trickier
+RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
+    && mkdir -p /usr/src/php/ext/memcached \
+    && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \
+    && docker-php-ext-configure memcached \
+    && docker-php-ext-install memcached \
+    && rm /tmp/memcached.tar.gz
 
 RUN usermod -u 1000 www-data
 


### PR DESCRIPTION
Add memcached support to laradock.

Installing memcached for PHP7 is a bit tricky. As far as I can see the other alternatives are just as unwieldy so you might want to comment it out and let users decide. 