### PR TITLE
Replacing phusion/baseimage to sunfoxcz/baseimage

### DIFF
--- a/beanstalkd/Dockerfile
+++ b/beanstalkd/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM sunfoxcz/baseimage:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 

--- a/beanstalkd/Dockerfile
+++ b/beanstalkd/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN apt-get update
+RUN apt-get update && apt-get upgrade
 RUN apt-get install -y beanstalkd
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8
 ENV TERM xterm
 
 # Install "software-properties-common" (for the "add-apt-repository")
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
     software-properties-common
 
 # Add the "PHP 7" ppa

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM sunfoxcz/baseimage:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 


### PR DESCRIPTION
sunfoxcz/baseimage is based on Ubuntu Xenial 16.4 since the official phusion/baseimage has not support it yet. It's also referencing issue #53