### PR TITLE
remove unnecessary data volume of redis.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
             - /var/lib/mysql
             - /var/lib/postgres
             - /var/lib/mariadb
-            - /var/lib/redis
             - /var/lib/memcached
             - /var/lib/neo4j/data
 
@@ -77,7 +76,7 @@ services:
 
 ### MariaDB Container #######################################
 
-    mariadb:  
+    mariadb:
         build: ./mariadb
         volumes_from:
             - data

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -2,10 +2,6 @@ FROM redis:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 
-#COPY redis.conf /usr/local/etc/redis/redis.conf
-
-VOLUME /var/lib/redis
-
 CMD [ "redis-server" ]
 
 EXPOSE 6379


### PR DESCRIPTION
The default volume of redis is `/data` so we don't need another volume `/var/lib/redis`. 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>