### PR TITLE
Support gd extension.

### DIFF
--- a/php-fpm/Dockerfile-55
+++ b/php-fpm/Dockerfile-55
@@ -9,13 +9,21 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     libmemcached-dev \
     curl \
+    libpng12-dev \
+    libfreetype6-dev \
     --no-install-recommends \
     && rm -r /var/lib/apt/lists/*
+
+# configure gd library
+RUN docker-php-ext-configure gd \
+    --enable-gd-native-ttf \
+    --with-freetype-dir=/usr/include/freetype2
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
     pdo_mysql \
-    pdo_pgsql
+    pdo_pgsql \
+    gd
 
 # Install memcached
 RUN pecl install memcached \

--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -9,13 +9,21 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     libmemcached-dev \
     curl \
+    libpng12-dev \
+    libfreetype6-dev \
     --no-install-recommends \
     && rm -r /var/lib/apt/lists/*
+
+# configure gd library
+RUN docker-php-ext-configure gd \
+    --enable-gd-native-ttf \
+    --with-freetype-dir=/usr/include/freetype2
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
     pdo_mysql \
-    pdo_pgsql
+    pdo_pgsql \
+    gd
 
 # Install memcached
 RUN pecl install memcached \

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -9,13 +9,21 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     libmemcached-dev \
     curl \
+    libpng12-dev \
+    libfreetype6-dev \
     --no-install-recommends \
     && rm -r /var/lib/apt/lists/*
+
+# configure gd library
+RUN docker-php-ext-configure gd \
+    --enable-gd-native-ttf \
+    --with-freetype-dir=/usr/include/freetype2
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
     pdo_mysql \
-    pdo_pgsql
+    pdo_pgsql \
+    gd
 
 # Install Memcached for php 7
 RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --force-yes \
         php7.0-sqlite3 \
         php7.0-zip \
         php7.0-memcached \
+        php7.0-gd \
         php-dev \
         libcurl4-openssl-dev \
         libedit-dev \


### PR DESCRIPTION
Hi @Mahmoudz 

I want install [Laravel captcha](https://github.com/mewebstudio/captcha) so we need install `gd` extension and support gd on command line.

Thanks.

![screen shot 2016-06-16 at 2 53 48 pm](https://cloud.githubusercontent.com/assets/21979/16108020/125ee75e-33d3-11e6-910c-f08b06c66fc4.png)

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>