### PR TITLE
(Workspace) Update NPM to v3 after install

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get clean
 
 # Install gulp and bower with NPM
 RUN npm install -g \
+    npm \
     gulp \
     bower
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -54,17 +54,19 @@ RUN apt-get update && apt-get install -y --force-yes \
 # Clean up, to free some space
 RUN apt-get clean
 
+# Add a symbolic link for Node
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+
+# Update NPM
+RUN npm install -g npm
+
 # Install gulp and bower with NPM
 RUN npm install -g \
-    npm \
     gulp \
     bower
 
 # Link the global gulp to be used locally
 RUN npm link gulp
-
-# Add a symbolic link for Node
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Add an alias for PHPUnit
 RUN echo "alias phpunit='./vendor/bin/phpunit'" >> ~/.bashrc


### PR DESCRIPTION
The version of NPM installed by the system package manager (~1.3.10) is quite old now, and is not supported by some recent tools. This patch updates it to the most recent version before installing Gulp and Bower.

I've also moved the symlink up higher as NPM encounters issues after the upgrade without this.

Thanks!