### PR TITLE
Added support to conditionally install Prestissimo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /logs
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,10 @@ services:
 ### Workspace Utilities Container ###########################
 
     workspace:
-        build: ./workspace
+        build:
+            context: ./workspace
+            args:
+                INSTALL_PRESTISSIMO: ${INSTALL_PRESTISSIMO}
         volumes_from:
             - application
         tty: true

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -88,3 +88,9 @@ RUN . ~/.bashrc
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /var/www/laravel
+
+# Install optional software
+ARG INSTALL_PRESTISSIMO=false
+RUN if [ "$INSTALL_PRESTISSIMO" = true ] ; then \
+        composer global require "hirak/prestissimo:^0.3"; \
+    fi


### PR DESCRIPTION
This is a bit of an odd one, so let me know what you think.

I've added an `INSTALL_PRESTISSIMO` argument to the workspace dockerfile which will conditionally run the relevant composer install if set to `true`. I like that idea it would only be installed if wanted, although in order to do this I'm running a bash `if` in the dockerfile itself - which could be considered a bit of a hack. Apart from this, it seems to be working well. It runs right at the end, so the cache for the rest of the container should never be invalidated.

One thing to note at the moment is that if no value is supplied you will receive a warning message when building. Is there any way to supply a default value in the `docker-compose.yml` file?

To try this out, create a `.env` file in the main directory and paste the below:

```bash
INSTALL_PRESTISSIMO=true
```