### PR TITLE
Added pkg-config to the PHP extentions and Tools that are installed from APT

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get update && apt-get install -y --force-yes \
         git \
         curl \
         vim \
-        nano
+        nano \
+	pkg-config
 
 # Clean up, to free some space
 RUN apt-get clean


### PR DESCRIPTION
The following warning was being displayed when any php command was issued : "PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/mongodb.so' - /usr/lib/php/20151012/mongodb.so: cannot open shared object file: No such file or directory in Unknown on line 0". 

This was because of an error when configuring the mongodb dynamic library : "Cannot find OpenSSL's libraries".

Installing the helper tool pkg-config allows the mongodb dynamic library to be configured when the image is being built.