### PR TITLE
Added dot file to maintain consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*]
+charset = utf-8
+
+[{Dockerfile,docker-compose.yml}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
My last commit used tabs where spaces was the standard. The editorconfig.org tool might prevent this in the future. Some editors already has the tool bundled, while there are plugins for other popular ones.

I did a the basic settings, Mahmoudz might want amend with the full style preferences. 
