### PR TITLE
Use workspace as non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ You can select your own combination of container form this list:
 docker exec -it {Workspace-Container-Name} bash
 ```
 Replace `{Workspace-Container-Name}` with your Workspace container name.
+<br />
+Add `--user=laradock` to have files created as your host's user. (don't forget to change the PUID (User id) and PGID (group id) variables in docker-compose.yml).
 <br>
 To find the containers names type `docker-compose ps`.
 
@@ -657,7 +659,7 @@ More details about this [here](https://github.com/jenssegers/laravel-mongodb#ins
 7 - Test it:
 
 - First let your Models extend from the Mongo Eloquent Model. Check the [documentation](https://github.com/jenssegers/laravel-mongodb#eloquent).
-- Enter the Workspace Container `docker exec -it laradock_workspace_1 bash`.
+- Enter the Workspace Container `docker exec -it --user=laradock laradock_workspace_1 bash`.
 - Migrate the Database `php artisan migrate`.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,10 @@ services:
             args:
                 - INSTALL_MONGO=false
                 - INSTALL_XDEBUG=false
-                - INSTALL_NODE=false
+                - INSTALL_NODE=true
                 - COMPOSER_GLOBAL_INSTALL=false
+                - PUID=1000
+                - PGID=1000
         volumes_from:
             - volumes_source
         tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             args:
                 - INSTALL_MONGO=false
                 - INSTALL_XDEBUG=false
-                - INSTALL_NODE=true
+                - INSTALL_NODE=false
                 - COMPOSER_GLOBAL_INSTALL=false
                 - PUID=1000
                 - PGID=1000

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -61,11 +61,24 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 ;fi
 
 #####################################
+# Non-Root User:
+#####################################
+
+# Add a non-root user to prevent files being created with root permissions on host machine.
+ARG PUID=1000
+ARG PGID=1000
+RUN groupadd -g $PGID laradock && \
+    useradd -u $PUID -g laradock -m laradock
+    
+# Now switch to our laradock user for the rest of user setup
+USER laradock
+
+#####################################
 # Composer:
 #####################################
 
 # Add the composer.json
-ADD ./composer.json /root/.composer/composer.json
+ADD ./composer.json /home/laradock/.composer/composer.json
 
 # Check if global install need to be runned
 ARG COMPOSER_GLOBAL_INSTALL=true
@@ -84,19 +97,27 @@ ARG INSTALL_NODE=true
 ENV INSTALL_NODE ${INSTALL_NODE}
 RUN if [ ${INSTALL_NODE} = true ]; then \
     # Install nvm (A Node Version Manager)
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
 ;fi
 # Again check if NVM needs to be installed
-# I had to split this condifiton link this because when I get it inside the above if statment is refuses to work!
+# I had to split this condition link this because when I get it inside the above if statement is refuses to work!
 ENV if [ ${INSTALL_NODE} = true ]; then \
     # Set the ENV
-    NVM_DIR=/root/.nvm \
+    NVM_DIR=/home/laradock/.nvm \
     # Install NodeJS with NVM
     RUN . ~/.nvm/nvm.sh && \
         nvm install stable && \
         nvm use stable && \
         nvm alias stable && \
         npm install -g gulp bower \
+;fi
+
+# Wouldn't execute when added to the RUN statement in the above block
+# Source NVM when loading bash since ~/.profile isn't loaded on non-login shell
+RUN if [ ${INSTALL_NODE} = true ]; then \
+    echo "" >> ~/.bashrc && \
+    echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc \
 ;fi
 
 #
@@ -106,6 +127,7 @@ ENV if [ ${INSTALL_NODE} = true ]; then \
 #
 
 # Clean up
+USER root
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
* Added a non-root user called laradock
* Specify PUID & PGID for the laradock's user id and group id (defaults to 1000)
* Use `docker-compose exec --user=laradock workspace bash` to login as the non-root laradock user.
* Closes #131 

This may still need some additional testing at this moment as I've only just gotten it working.
As always, let me know if some adjustments need to be made.