### PR TITLE
add options INSTALL_ZIP_ARCHIVE to php-fpm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
             args:
                 - INSTALL_MONGO=false
                 - INSTALL_XDEBUG=false
+                - INSTALL_ZIP_ARCHIVE=false
             dockerfile: Dockerfile-70
         volumes_from:
             - volumes_source

--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -35,6 +35,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #
 #   - INSTALL_XDEBUG=           false
 #   - INSTALL_MONGO=            false
+#   - INSTALL_ZIP_ARCHIVE=      false
 #
 
 #####################################
@@ -59,6 +60,18 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
     # Install the mongodb extention
     pecl install mongodb \
 ;fi
+
+#####################################
+# ZipArchive:
+#####################################
+
+ARG INSTALL_ZIP_ARCHIVE=true
+ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
+RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
+    # Install the zip extention
+    pecl install zip \
+;fi
+
 
 #
 #--------------------------------------------------------------------------

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -35,6 +35,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #
 #   - INSTALL_XDEBUG=           false
 #   - INSTALL_MONGO=            false
+#   - INSTALL_ZIP_ARCHIVE=      false
 #
 
 #####################################
@@ -59,6 +60,18 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
     # Install the mongodb extention
     pecl install mongodb \
 ;fi
+
+#####################################
+# ZipArchive:
+#####################################
+
+ARG INSTALL_ZIP_ARCHIVE=true
+ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
+RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
+    # Install the zip extention
+    pecl install zip \
+;fi
+
 
 #
 #--------------------------------------------------------------------------

--- a/php-fpm/laravel.ini
+++ b/php-fpm/laravel.ini
@@ -2,6 +2,7 @@ date.timezone=UTC
 display_errors=Off
 log_errors=On
 extension=mongodb.so
+extension=zip.so
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
add zip support for php-fpm..

because when somebody want to use or [laravel-excel](https://github.com/Maatwebsite/Laravel-Excel) or [PHPExcel](https://phpexcel.codeplex.com) to load *.xlsx file, extension php_zip is requirement..