### PR TITLE
Remove hard-coded extensions from laravel.ini

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -45,7 +45,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 ARG INSTALL_XDEBUG=true
 ENV INSTALL_XDEBUG ${INSTALL_XDEBUG}
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
-    # Install the xdebug extention
+    # Install the xdebug extension
     pecl install xdebug && \
     docker-php-ext-enable xdebug \
 ;fi
@@ -57,8 +57,9 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
 ARG INSTALL_MONGO=true
 ENV INSTALL_MONGO ${INSTALL_MONGO}
 RUN if [ ${INSTALL_MONGO} = true ]; then \
-    # Install the mongodb extention
-    pecl install mongodb \
+    # Install the mongodb extension
+    pecl install mongodb && \
+    docker-php-ext-enable mongodb \
 ;fi
 
 #####################################
@@ -68,8 +69,9 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 ARG INSTALL_ZIP_ARCHIVE=true
 ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
 RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
-    # Install the zip extention
-    pecl install zip \
+    # Install the zip extension
+    pecl install zip && \
+    docker-php-ext-enable zip \
 ;fi
 
 

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -45,7 +45,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 ARG INSTALL_XDEBUG=true
 ENV INSTALL_XDEBUG ${INSTALL_XDEBUG}
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
-    # Install the xdebug extention
+    # Install the xdebug extension
     pecl install xdebug && \
     docker-php-ext-enable xdebug \
 ;fi
@@ -57,8 +57,9 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
 ARG INSTALL_MONGO=true
 ENV INSTALL_MONGO ${INSTALL_MONGO}
 RUN if [ ${INSTALL_MONGO} = true ]; then \
-    # Install the mongodb extention
-    pecl install mongodb \
+    # Install the mongodb extension
+    pecl install mongodb && \
+    docker-php-ext-enable mongodb \
 ;fi
 
 #####################################
@@ -68,8 +69,9 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 ARG INSTALL_ZIP_ARCHIVE=true
 ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
 RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
-    # Install the zip extention
-    pecl install zip \
+    # Install the zip extension
+    pecl install zip && \
+    docker-php-ext-enable zip \
 ;fi
 
 

--- a/php-fpm/laravel.ini
+++ b/php-fpm/laravel.ini
@@ -1,8 +1,6 @@
 date.timezone=UTC
 display_errors=Off
 log_errors=On
-extension=mongodb.so
-extension=zip.so
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
This should prevent a couple warning messages mentioned by @LarryEitel in Gitter. The `docker-php-ext-enable` used in the Dockerfile uses a list of all available extensions in PHP's `extension_dir` directory - so future extensions installed via `pecl` can be activated in the same way.

It may even be possible to take an array of extensions instead of using `INSTALL_X` for each one - but perhaps that would be making things a little too complicated.

Quick and dirty patch, so please check this just in case!