### PR TITLE
Provided a way to Stop/Start php-fpm xdebug via bash script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,8 +957,12 @@ Use `http://127.0.0.1` instead of `http://localhost` in your browser.
 
 Make sure the ports for the services that you are trying to run (80, 3306, etc.) are not being used already by other programs, such as a built in `apache`/`httpd` service or other development tools you have installed.
 
+#### Stopping and Starting xdebug
 
-
+By default, if you have chosen to install xDebug, it will be running/enabled on startup. 
+- To stop xdebug in the `php-fpm` container, from your laradock folder, run: `./xdebugPhpFpm stop`.
+- To start, run: `./xdebugPhpFpm start`.
+- To see php -v, run: `./xdebugPhpFpm status`.
 
 <br>
 <a name="upgrading-laradock"></a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
                 - PGID=1000
         volumes_from:
             - volumes_source
+        extra_hosts:
+            # IMPORTANT: Replace with your Docker Host IP
+            # this will be appended to /etc/hosts
+            # Note that this IP can perhaps be better injected via .env
+            - "dockerhost:10.0.75.1"
         tty: true
 
 ### PHP-FPM Container #######################################
@@ -34,6 +39,17 @@ services:
             - "9000"
         links:
             - workspace
+        extra_hosts:
+            # IMPORTANT: Replace with your Docker Host IP
+            # this will be appended to /etc/hosts
+            # Note that this IP can perhaps be better injected via .env
+            - "dockerhost:10.0.75.1"
+        environment:
+            # IMPORTANT: You must have a Remote Interpreter entry matching this name
+            # In settings, search for interpreter...
+            # PHP > Languages & Frameworks > PHP > Interpreter > click on [...]
+            # Need to have a Remote Interpreter named 'laravel'
+            - PHP_IDE_CONFIG="serverName=laravel"
 
 ### Nginx Server Container ##################################
 

--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -49,6 +49,8 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     pecl install xdebug && \
     docker-php-ext-enable xdebug \
 ;fi
+# ADD for REMOTE debugging
+COPY ./xdebug_settings_only.ini /usr/local/etc/php/conf.d/xdebug_settings_only.ini
 
 #####################################
 # MongoDB:

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -49,6 +49,8 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     pecl install xdebug && \
     docker-php-ext-enable xdebug \
 ;fi
+# ADD for REMOTE debugging
+COPY ./xdebug_settings_only.ini /usr/local/etc/php/conf.d/xdebug_settings_only.ini
 
 #####################################
 # MongoDB:

--- a/php-fpm/xdebug_settings_only.ini
+++ b/php-fpm/xdebug_settings_only.ini
@@ -1,0 +1,21 @@
+; NOTE: The actual debug.so extention is NOT SET HERE but rather
+; /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+; For example:
+; zend_extension=xdebug.so
+
+xdebug.remote_autostart=1
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.remote_mode=req
+
+; In PHPStorm: Settings > Languages & Frameworks > PHP > Debug > Xdebug > Debug port
+xdebug.remote_port=9000
+
+; This is passed with by docker-compose / workspace / extra_hosts / - "dockerhost:10.0.75.1"
+; It will set 10.0.75.1 dockerhost
+; This will allow xdebug to connect to the host running PHPStorm.
+xdebug.remote_host=dockerhost
+
+; PHPStorm needs this
+xdebug.idekey=PHPSTORM
+

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -52,6 +52,8 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     sed -i 's/^/;/g' /etc/php/7.0/cli/conf.d/20-xdebug.ini && \
     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/laravel/vendor/bin/phpunit'" >> ~/.bashrc \
 ;fi
+# ADD for REMOTE debugging
+COPY ./xdebug_settings_only.ini /etc/php/7.0/cli/conf.d/xdebug_settings_only.ini
 
 #####################################
 # MongoDB:

--- a/workspace/xdebug_settings_only.ini
+++ b/workspace/xdebug_settings_only.ini
@@ -1,0 +1,20 @@
+; NOTE: The actual debug.so extention is NOT SET HERE but rather
+; /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+; For example:
+; zend_extension=xdebug.so
+
+xdebug.remote_autostart=1
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.remote_mode=req
+
+; In PHPStorm: Settings > Languages & Frameworks > PHP > Debug > Xdebug > Debug port
+xdebug.remote_port=9000
+
+; This is passed with by docker-compose / workspace / extra_hosts / - "dockerhost:10.0.75.1"
+; It will set 10.0.75.1 dockerhost
+; This will allow xdebug to connect to the host running PHPStorm.
+xdebug.remote_host=dockerhost
+
+; PHPStorm needs this
+xdebug.idekey=PHPSTORM

--- a/xdebugPhpFpm
+++ b/xdebugPhpFpm
@@ -1,0 +1,91 @@
+#! /bin/bash
+
+# NOTE: At the moment, this has only been confirmed to work PHP 7
+
+
+# Grab full name of php-fpm container
+PHP_FPM_CONTAINER=$(docker-compose ps | grep php-fpm | cut -d" " -f 1)
+
+xdebug_status ()
+{
+    echo 'xDebug status'
+
+    # If running on Windows, need to prepend with winpty :(
+    if [[ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]]; then
+        winpty docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+
+    else
+        docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+    fi
+
+}
+
+xdebug_start ()
+{
+    echo 'Start xDebug'
+
+    # And uncomment line with xdebug extension, thus enabling it
+    ON_CMD="sed -i 's/^;zend_extension=/zend_extension=/g' \
+                    /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+
+
+    # If running on Windows, need to prepend with winpty :(
+    if [[ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]]; then
+        winpty docker exec -it $PHP_FPM_CONTAINER bash -c "${ON_CMD}"
+        docker restart $PHP_FPM_CONTAINER
+        winpty docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+
+    else
+        docker exec -it $PHP_FPM_CONTAINER bash -c "${ON_CMD}"
+        docker restart $PHP_FPM_CONTAINER
+        docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+    fi
+
+}
+
+xdebug_stop ()
+{
+    echo 'Stop xDebug'
+
+    # Comment out xdebug extension line
+    OFF_CMD="sed -i 's/^zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+
+
+    # If running on Windows, need to prepend with winpty :(
+    if [[ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]]; then
+        # This is the equivalent of:
+        # winpty docker exec -it laradock_php-fpm_1 bash -c 'bla bla bla'
+        # Thanks to @michaelarnauts at https://github.com/docker/compose/issues/593
+        winpty docker exec -it $PHP_FPM_CONTAINER bash -c "${OFF_CMD}"
+        docker restart $PHP_FPM_CONTAINER
+        #docker-compose restart php-fpm
+        winpty docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+
+    else
+        docker exec -it $PHP_FPM_CONTAINER bash -c "${OFF_CMD}"
+        # docker-compose restart php-fpm
+        docker restart $PHP_FPM_CONTAINER
+        docker exec -it $PHP_FPM_CONTAINER bash -c 'php -v'
+    fi
+}
+
+
+case $@ in
+    stop|STOP)
+        xdebug_stop
+        ;;
+    start|START)
+        xdebug_start
+        ;;
+    status|STATUS)
+        xdebug_status
+        ;;
+    *)
+        echo "xDebug [Stop | Start | Status] in the ${PHP_FPM_CONTAINER} container."
+        echo "xDebug must have already been installed."
+        echo "Usage:"
+        echo "  ./xdebugPhpFpm stop|start|status"
+
+esac
+
+exit 1


### PR DESCRIPTION
This is an important step toward support for full remote debugging. To try this branch, enable `xdebug` on `php-fpm` container and then run `./xdebugPhpFpm`.