### PR TITLE
Multi site framework agnostic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
                 - INSTALL_MONGO=false
                 - INSTALL_XDEBUG=false
                 - INSTALL_NODE=false
+                - INSTALL_DRUSH=false
                 - COMPOSER_GLOBAL_INSTALL=false
                 - PUID=1000
                 - PGID=1000
@@ -33,6 +34,7 @@ services:
                 - INSTALL_XDEBUG=false
                 - INSTALL_ZIP_ARCHIVE=false
                 - INSTALL_MEMCACHED=false
+                - INSTALL_OPCACHE=false
             dockerfile: Dockerfile-70
         volumes_from:
             - volumes_source

--- a/nginx/sites/framework-examples/drupal_8.conf
+++ b/nginx/sites/framework-examples/drupal_8.conf
@@ -1,28 +1,56 @@
 server {
-    listen 80;
+    listen   80;
     listen [::]:80;
 
-    server_name  site_a.dev;
-    root /var/www/site_a;
-    index index.php;
+    #domain name
+    server_name drupal8.dev;
 
+    #file document root. This has to match one of the volumes in docer-composer.yml
+    root /var/www/drupal8;
+
+    # This is the full path to your index file
+    index index.php index.html index.htm;
+
+
+    ## serve imagecache files directly or redirect to drupal if they do not exist.
+    location ~* files/styles {
+      access_log off;
+      expires 30d;
+      try_files $uri @drupal;
+    }
+
+    ## serve imagecache files directly or redirect to drupal if they do not exist.
+    location ~* ^.+.(xsl|xml)$ {
+        access_log off;
+        expires 1d;
+        try_files $uri @drupal;
+    }
+
+    ## Images and static content is treated different
+    location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|xml)$ {
+        access_log        off;
+        expires           30d;
+    }
 
     location / {
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        index index.php;
+        # This is cool because no php is touched for static content
+        try_files $uri $uri/ @rewrite;
+        expires max;
     }
 
-    error_page 404 /404.html;
-    error_page 500 502 503 504 /50x.html;
-    location = /50x.html {
-          root /var/www/site_a;
+    location @drupal {
+        rewrite ^/(.*)$ /index.php?q=$1 last;
     }
 
-    location ~ [^/]\.php(/|$) {
-        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-        if (!-f $document_root$fastcgi_script_name) {
-            return 404;
-        }
 
+    location @rewrite {
+        # Some modules enforce no slash (/) at the end of the URL
+        # Else this rewrite block wouldn&#39;t be needed (GlobalRedirect)
+        rewrite ^/(.*)$ /index.php?q=$1;
+    }
+
+    location ~ .php$ {
         fastcgi_pass php-upstream;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/nginx/sites/framework-examples/drupal_8.conf
+++ b/nginx/sites/framework-examples/drupal_8.conf
@@ -1,0 +1,31 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name  site_a.dev;
+    root /var/www/site_a;
+    index index.php;
+
+
+    location / {
+        try_files $uri $uri/ /index.php?q=$uri&$args;
+    }
+
+    error_page 404 /404.html;
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+          root /var/www/site_a;
+    }
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        if (!-f $document_root$fastcgi_script_name) {
+            return 404;
+        }
+
+        fastcgi_pass php-upstream;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+}

--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -92,8 +92,12 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
 #####################################
 # Opcache:
 #####################################
-RUN docker-php-ext-install opcache
-RUN docker-php-ext-enable opcache
+ARG INSTALL_OPCACHE=true
+ENV INSTALL_OPCACHE ${INSTALL_OPCACHE}
+RUN if [ ${INSTALL_OPCACHE} = true ]; then \
+    docker-php-ext-install opcache && \
+    docker-php-ext-enable opcache \
+;fi
 
 
 #

--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -89,6 +89,12 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
     docker-php-ext-enable memcached \
 ;fi
 
+#####################################
+# Opcache:
+#####################################
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-enable opcache
+
 
 #
 #--------------------------------------------------------------------------

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -103,8 +103,13 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
 #####################################
 # Opcache:
 #####################################
-RUN docker-php-ext-install opcache
-RUN docker-php-ext-enable opcache
+ARG INSTALL_OPCACHE=true
+ENV INSTALL_OPCACHE ${INSTALL_OPCACHE}
+RUN if [ ${INSTALL_OPCACHE} = true ]; then \
+    docker-php-ext-install opcache && \
+    docker-php-ext-enable opcache \
+;fi
+
 
 
 #

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -100,6 +100,12 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
     && docker-php-ext-enable memcached \
 ;fi
 
+#####################################
+# Opcache:
+#####################################
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-enable opcache
+
 
 #
 #--------------------------------------------------------------------------

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -98,6 +98,20 @@ RUN if [ ${COMPOSER_GLOBAL_INSTALL} = true ]; then \
 ;fi
 
 #####################################
+# Drush:
+#####################################
+ENV DRUSH_VERSION 8.1.2
+
+# Install Drush 8 with the phar file.
+USER root
+RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \
+  chmod +x /usr/local/bin/drush
+
+#Check if drush works for the laradock user
+USER laradock
+RUN drush core-status
+
+#####################################
 # Node / NVM:
 #####################################
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -37,7 +37,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #   - INSTALL_MONGO=            false
 #   - COMPOSER_GLOBAL_INSTALL=  false
 #   - INSTALL_NODE=             false
-#   - INSTALL_drush=            false
+#   - INSTALL_DRUSH=            false
 #
 
 #####################################

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -37,6 +37,7 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #   - INSTALL_MONGO=            false
 #   - COMPOSER_GLOBAL_INSTALL=  false
 #   - INSTALL_NODE=             false
+#   - INSTALL_drush=            false
 #
 
 #####################################
@@ -100,16 +101,18 @@ RUN if [ ${COMPOSER_GLOBAL_INSTALL} = true ]; then \
 #####################################
 # Drush:
 #####################################
-ENV DRUSH_VERSION 8.1.2
-
-# Install Drush 8 with the phar file.
 USER root
-RUN curl -fsSL -o /usr/local/bin/drush "https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar" && \
-  chmod +x /usr/local/bin/drush
+ENV DRUSH_VERSION 8.1.2
+ARG INSTALL_DRUSH=true
+ENV INSTALL_DRUSH ${INSTALL_DRUSH}
+RUN if [ ${INSTALL_DRUSH} = true ]; then \
+    # Install Drush 8 with the phar file.
+    curl -fsSL -o /usr/local/bin/drush https://github.com/drush-ops/drush/releases/download/$DRUSH_VERSION/drush.phar | bash && \
+    chmod +x /usr/local/bin/drush && \
+    drush core-status \
+;fi
 
-#Check if drush works for the laradock user
 USER laradock
-RUN drush core-status
 
 #####################################
 # Node / NVM:


### PR DESCRIPTION
This will allow laradock to become framework agnostic building on PR #231 . This adds a folder for example conf files which contains a drupal 8 example. This will also install opcache in the PHP-FPM container and Drush in the workspace container.