### PR TITLE
Laravel 5.3 is published officially

### DIFF
--- a/_guides/digital_ocean.md
+++ b/_guides/digital_ocean.md
@@ -32,7 +32,6 @@ $root@midascode:~# docker
 $root@midascode:~# apt-get install git
 $root@midascode:~# git clone https://github.com/laravel/laravel
 $root@midascode:~# cd laravel
-$root@midascode:~/laravel# git checkout develop
 $root@midascode:~/laravel/ git submodule add https://github.com/LaraDock/laradock.git
 $root@midascode:~/laravel/ cd laradock
 ```


### PR DESCRIPTION
No need for development branch switch.

Ran into the same error posted by this guy here https://laracasts.com/discuss/channels/laravel/laravel-53-cant-do-php-artisan-optimize.

I didn't switch to the development branch and the setup worked perfectly.