### PR TITLE
Update caddy server and log to file

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,9 +9,10 @@ rewrite {
     ext /
     to /index.php?{query}
 }
+gzip
 browse
-log stdout
-errors stderr
+log /var/log/caddy/access.log
+errors /var/log/caddy/error.log
 # Uncomment to enable TLS (HTTPS)
 # Change the first list to listen on port 443 when enabling TLS
 #tls self_signed

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.4
 
 MAINTAINER Eric Pfeiffer <computerfr33k@users.noreply.github.com>
 
-LABEL caddy_version="0.9.1" architecture="amd64"
+ENV caddy_version=0.9.1
+
+LABEL caddy_version="$caddy_version" architecture="amd64"
 
 RUN apk update \
     && apk upgrade \
@@ -10,14 +12,13 @@ RUN apk update \
 
 RUN curl --silent --show-error --fail --location \
       --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-      "https://github.com/mholt/caddy/releases/download/v0.9.1/caddy_linux_amd64.tar.gz" \
+      "https://github.com/mholt/caddy/releases/download/v$caddy_version/caddy_linux_amd64.tar.gz" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy_linux_amd64 \
  && mv /usr/bin/caddy_linux_amd64 /usr/bin/caddy \
- && chmod 0755 /usr/bin/caddy \
- && /usr/bin/caddy -version
+ && chmod 0755 /usr/bin/caddy
 
 EXPOSE 80 443 2015
 
 WORKDIR /var/www/laravel/public
 
-CMD ["caddy" "-conf", "/etc/Caddyfile"]
+CMD ["/usr/bin/caddy", "-conf", "/etc/Caddyfile"]

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 MAINTAINER Eric Pfeiffer <computerfr33k@users.noreply.github.com>
 
-LABEL caddy_version="0.9.0" architecture="amd64"
+LABEL caddy_version="0.9.1" architecture="amd64"
 
 RUN apk update \
     && apk upgrade \
@@ -10,7 +10,7 @@ RUN apk update \
 
 RUN curl --silent --show-error --fail --location \
       --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-      "https://github.com/mholt/caddy/releases/download/v0.9.0/caddy_linux_amd64.tar.gz" \
+      "https://github.com/mholt/caddy/releases/download/v0.9.1/caddy_linux_amd64.tar.gz" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy_linux_amd64 \
  && mv /usr/bin/caddy_linux_amd64 /usr/bin/caddy \
  && chmod 0755 /usr/bin/caddy \
@@ -20,6 +20,4 @@ EXPOSE 80 443 2015
 
 WORKDIR /var/www/laravel/public
 
-ENTRYPOINT ["caddy"]
-
-CMD ["-conf", "/etc/Caddyfile"]
+CMD ["caddy" "-conf", "/etc/Caddyfile"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,7 @@ services:
             - "2015:2015"
         volumes:
             - ./caddy/Caddyfile:/etc/Caddyfile
+            - ./logs/caddy:/var/log/caddy
         links:
             - php-fpm
 


### PR DESCRIPTION
* upgrade caddy to v0.9.1
* Log access and errors to file instead of stdout
* closes #248 