### PR TITLE
Remove env commands from php fpm

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -41,7 +41,6 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #####################################
 
 ARG INSTALL_XDEBUG=true
-ENV INSTALL_XDEBUG ${INSTALL_XDEBUG}
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Install the xdebug extension
     pecl install xdebug && \
@@ -56,7 +55,6 @@ COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 #####################################
 
 ARG INSTALL_MONGO=true
-ENV INSTALL_MONGO ${INSTALL_MONGO}
 RUN if [ ${INSTALL_MONGO} = true ]; then \
     # Install the mongodb extension
     pecl install mongodb && \
@@ -68,7 +66,6 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 #####################################
 
 ARG INSTALL_ZIP_ARCHIVE=true
-ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
 RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
     # Install the zip extension
     pecl install zip && \
@@ -80,7 +77,6 @@ RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
 #####################################
 
 ARG INSTALL_MEMCACHED=true
-ENV INSTALL_MEMCACHED ${INSTALL_MEMCACHED}
 RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
     # Install the php memcached extension
     pecl install memcached && \
@@ -91,7 +87,6 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
 # Opcache:
 #####################################
 ARG INSTALL_OPCACHE=true
-ENV INSTALL_OPCACHE ${INSTALL_OPCACHE}
 RUN if [ ${INSTALL_OPCACHE} = true ]; then \
     docker-php-ext-install opcache && \
     docker-php-ext-enable opcache \

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -41,7 +41,6 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 #####################################
 
 ARG INSTALL_XDEBUG=true
-ENV INSTALL_XDEBUG ${INSTALL_XDEBUG}
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Install the xdebug extension
     pecl install xdebug && \
@@ -56,7 +55,6 @@ COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 #####################################
 
 ARG INSTALL_MONGO=true
-ENV INSTALL_MONGO ${INSTALL_MONGO}
 RUN if [ ${INSTALL_MONGO} = true ]; then \
     # Install the mongodb extension
     pecl install mongodb && \
@@ -68,7 +66,6 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 #####################################
 
 ARG INSTALL_ZIP_ARCHIVE=true
-ENV INSTALL_ZIP_ARCHIVE ${INSTALL_ZIP_ARCHIVE}
 RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
     # Install the zip extension
     pecl install zip && \
@@ -80,7 +77,6 @@ RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
 #####################################
 
 ARG INSTALL_MEMCACHED=true
-ENV INSTALL_MEMCACHED ${INSTALL_MEMCACHED}
 RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
     # Install the php memcached extension
     curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
@@ -102,7 +98,6 @@ RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
 # Opcache:
 #####################################
 ARG INSTALL_OPCACHE=true
-ENV INSTALL_OPCACHE ${INSTALL_OPCACHE}
 RUN if [ ${INSTALL_OPCACHE} = true ]; then \
     docker-php-ext-install opcache && \
     docker-php-ext-enable opcache \


### PR DESCRIPTION
These environment variables are not needed since they are only being used at build time and we are already specifying them using the ARG command, no need to specify it twice since it increases build time and size.

Also, I think it would be a good idea to not have php-fpm container linked to the workspace container since it doesn't actually depend on it for anything and some people might not want the workspace to run when starting php-fpm. Like me for example, do not need the workspace container to be running since I do not need it for anything and memory on my system is low just from having phpstorm running as it is. (I know this isn't related to this PR, but thought I'd ask.)