### PR TITLE
fix #267 phpmyadmin is not working on linux.

### DIFF
--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -7,5 +7,3 @@ VOLUME /sessions
 
 # We expose phpMyAdmin on port 80
 EXPOSE 80
-
-ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
`phpMyAdmin` can't working on `Linux`, only working for `MAC`

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>