### PR TITLE
fix workspace xdebug install bug - need to add apt-get update.

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -49,6 +49,7 @@ ARG INSTALL_XDEBUG=true
 ENV INSTALL_XDEBUG ${INSTALL_XDEBUG}
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
+    apt-get update && \
     apt-get install -y --force-yes php7.0-xdebug && \
     sed -i 's/^/;/g' /etc/php/7.0/cli/conf.d/20-xdebug.ini && \
     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/laravel/vendor/bin/phpunit'" >> ~/.bashrc \


### PR DESCRIPTION
Fix workspace xdebug install bug - need to add apt-get update. Note that this is a quick hack that works for me. Not fully tested.