### PR TITLE
Feature/vue cli workspace

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -154,7 +154,7 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
         nvm install ${NODE_VERSION} && \
         nvm use ${NODE_VERSION} && \
         nvm alias ${NODE_VERSION} && \
-        npm install -g gulp bower \
+        npm install -g gulp bower vue-cli \
 ;fi
 
 # Wouldn't execute when added to the RUN statement in the above block


### PR DESCRIPTION
Fix #290
Added the vue-cli to work in Laravel 5.3 in global npm installation at workspace dockerfile.