### PR TITLE
fix php warning in Workspace: "Unable to load dynamic library aerospike"

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -186,6 +186,9 @@ RUN if [ ${INSTALL_AEROSPIKE_EXTENSION} = true ]; then \
     ) \
     && rm /tmp/aerospike-client-php.tar.gz \
 ;fi
+RUN if [ ${INSTALL_AEROSPIKE_EXTENSION} = false ]; then \
+    rm /etc/php/7.0/cli/conf.d/aerospike.ini \
+;fi
 
 #
 #--------------------------------------------------------------------------


### PR DESCRIPTION
fix php warning "Unable to load dynamic library '/usr/lib/php/20151012/aerospike.so'" when aerospike set not install at workspace