### PR TITLE
Revert #297 add mysql custom configuration file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,10 +101,7 @@ services:
 ### MySQL Container #########################################
 
     mysql:
-        build:
-            context: ./mysql
-            args:
-                - MAX_ALLOWED_PACKET=20M
+        build: ./mysql
         volumes_from:
             - volumes_data
         ports:

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -2,11 +2,7 @@ FROM mysql:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 
-ARG MAX_ALLOWED_PACKET=1M
-ENV MAX_ALLOWED_PACKET ${MAX_ALLOWED_PACKET}
-
-# Set MAX_ALLOWED_PACKET to /etc/mysql/my.cnf
-RUN sed -i "s/^\[mysqld\]$/\[mysqld\]\nmax_allowed_packet = ${MAX_ALLOWED_PACKET}/g" /etc/mysql/my.cnf
+ADD my.cnf /etc/mysql/conf.d/my.cnf
 
 CMD ["mysqld"]
 

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,6 @@
+# The MySQL  Client configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysql]


### PR DESCRIPTION
Revert #297 PR.

I added mysql custom configuration file. Anyone can put your custom configuration to `my.cnf` and rebuild mysql container as the following command.

```bash
$ docker-compose build --no-cache mysql
```

cc @lialosiu