### PR TITLE
Windows Powershell command to enter container

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ You can select your own combination of Containers form the list below:
 docker-compose exec workspace bash
 ```
 <br />
+<br>
+2a - Alternatively, Windows Powershell users can execute the following command to enter a running container.
+```bash
+docker exec -it {container-id} bash
+```
+<br />
 Add `--user=laradock` (example `docker-compose exec --user=laradock workspace bash`) to have files created as your host's user. (you can change the PUID (User id) and PGID (group id) variables from the `docker-compose.yml`).
 
 


### PR DESCRIPTION
Allows a Windows Powershell user to enter a running container to avoid the following error message.
Interactive mode is not yet supported on Windows.
Please pass the -d flag when using `docker-compose exec`.