### PR TITLE
Added NVM binaries in root bashrc

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -165,6 +165,14 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
     echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc \
 ;fi
 
+# Add NVM binaries to root's .bashrc
+USER root
+RUN if [ ${INSTALL_NODE} = true ]; then \
+    echo "" >> ~/.bashrc && \
+    echo 'export NVM_DIR="/home/laradock/.nvm"' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc \
+;fi
+
 #####################################
 # PHP Aerospike:
 #####################################


### PR DESCRIPTION
The `root` user should now have access to the NVM binaries.

Fixes #309