### PR TITLE
Remove port fowarding for MySQL and MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,8 +104,6 @@ services:
         build: ./mysql
         volumes_from:
             - volumes_data
-        ports:
-            - "3306:3306"
         environment:
             MYSQL_DATABASE: homestead
             MYSQL_USER: homestead
@@ -131,8 +129,6 @@ services:
         build: ./mariadb
         volumes_from:
             - volumes_data
-        ports:
-            - "3306:3306"
         environment:
             MYSQL_DATABASE: homestead
             MYSQL_USER: homestead


### PR DESCRIPTION
As discussed in #332, the database ports should not be forwarded by default since there is no way to override array values currently.

The dockerfiles for both the MySQL and MariaDB already expose the 3306 port so there is no need to do it again in the `docker-compose.yml`.

I only made the change for the MySQL and MariaDB since these are the ones I used, if this PR is considered I'll take the time to test all the other database containers for potential shortfalls.