### PR TITLE
Added timezone arguments to workspace build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It's like Laravel Homestead but for Docker instead of Vagrant.
 		- [Prepare LaraDock for Production](#LaraDock-for-Production)
 		- [Setup Laravel and Docker on Digital Ocean](#Digital-Ocean)
 	- [Misc](#Misc)
+		- [Change the timezone](#Change-the-timezone)
 		- [Cron jobs](#CronJobs)
 		- [MySQL access from host](#MySQL-access-from-host)
 		- [Use custom Domain](#Use-custom-Domain)
@@ -985,6 +986,24 @@ To learn more about how Docker publishes ports, please read [this excellent post
 
 <br>
 
+<a name="Change-the-timezone"></a>
+### Change the timezone
+
+To change the timezone for the `workspace` container, modify the `TZ` build argument in the Docker Compose file to one in the [TZ database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+For example, if I want the timezone to be `New York`:
+
+```yml
+	workspace:
+		build:
+			context: ./workspace
+			args:
+				- TZ=America/New_York
+	...
+```
+
+We also recommend [setting the timezone in Laravel](http://www.camroncade.com/managing-timezones-with-laravel/).
+
 <a name="CronJobs"></a>
 ### Adding cron jobs
 
@@ -996,6 +1015,8 @@ You can add your cron jobs to `workspace/crontab/root` after the `php artisan` l
 # Custom cron
 * * * * * root echo "Every Minute" > /var/log/cron.log 2>&1
 ```
+
+Make sure you [change the timezone](#Change-the-timezone) if you don't want to use the default (UTC).
 
 <a name="MySQL-access-from-host"></a>
 ### MySQL access from host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
                 - PUID=1000
                 - PGID=1000
                 - NODE_VERSION=stable
+                - TZ=UTC
         volumes_from:
             - volumes_source
         extra_hosts:

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -46,6 +46,14 @@ ARG PUID=1000
 ARG PGID=1000
 RUN groupadd -g $PGID laradock && \
     useradd -u $PUID -g laradock -m laradock
+    
+#####################################
+# Set Timezone
+#####################################
+
+ARG TZ=UTC
+ENV TZ ${TZ}
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 #####################################
 # Composer:


### PR DESCRIPTION
This PR should make it easier to manage the timezone in the workspace container since we now have crons (and we don't want those running at the wrong time do we?).

Fixes #318