### PR TITLE
Support Yarn package manager for JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ It's like Laravel Homestead but for Docker instead of Vagrant.
 		- [Enable Global Composer Build Install](#Enable-Global-Composer-Build-Install)
 		- [Install Prestissimo](#Install-Prestissimo)
 		- [Install Node + NVM](#Install-Node)
+		- [Install Node + YARN](#Install-Yarn)
 		- [Debugging](#debugging)
 		- [Upgrading LaraDock](#upgrading-laradock)
 - [Help & Questions](#Help)
@@ -1120,6 +1121,30 @@ It should be like this:
             context: ./workspace
             args:
                 - INSTALL_NODE=true
+    ...
+```
+
+3 - Re-build the container `docker-compose build workspace`
+
+<br>
+<a name="Install-Yarn"></a>
+### Install Node + YARN
+
+Yarn is a new package manager for JavaScript. It is so faster than npm, which you can find [here](http://yarnpkg.com/en/compare).To install NodeJS and [Yarn](https://yarnpkg.com/) in the Workspace container:
+
+1 - Open the `docker-compose.yml` file
+
+2 - Search for the `INSTALL_NODE` and `INSTALL_YARN` argument under the Workspace Container and set it to `true`
+
+It should be like this:
+
+```yml
+    workspace:
+        build:
+            context: ./workspace
+            args:
+                - INSTALL_NODE=true
+                - INSTALL_YARN=true
     ...
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
                 - INSTALL_XDEBUG=false
                 - INSTALL_MONGO=false
                 - INSTALL_NODE=false
+                - INSTALL_YARN=false
                 - INSTALL_DRUSH=false
                 - INSTALL_AEROSPIKE_EXTENSION=false
                 - COMPOSER_GLOBAL_INSTALL=false

--- a/production-docker-compose.yml
+++ b/production-docker-compose.yml
@@ -11,6 +11,7 @@ services:
                 - INSTALL_XDEBUG=false
                 - INSTALL_MONGO=false
                 - INSTALL_NODE=false
+                - INSTALL_YARN=false
                 - INSTALL_DRUSH=false
                 - INSTALL_AEROSPIKE_EXTENSION=false
                 - COMPOSER_GLOBAL_INSTALL=false

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -182,6 +182,30 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
 ;fi
 
 #####################################
+# YARN:
+#####################################
+
+USER laradock
+
+ARG INSTALL_YARN=false
+ENV INSTALL_YARN ${INSTALL_YARN}
+
+RUN if [ ${INSTALL_YARN} = true ]; then \
+    curl -o- -L https://yarnpkg.com/install.sh | bash && \
+        echo "" >> ~/.bashrc && \
+        echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> ~/.bashrc \
+;fi
+
+# Add YARN binaries to root's .bashrc
+USER root
+
+RUN if [ ${INSTALL_YARN} = true ]; then \
+    echo "" >> ~/.bashrc && \
+    echo 'export YARN_DIR="/home/laradock/.yarn"' >> ~/.bashrc && \
+    echo 'export PATH="$YARN_DIR/bin:$PATH"' >> ~/.bashrc \
+;fi
+
+#####################################
 # PHP Aerospike:
 #####################################
 USER root


### PR DESCRIPTION
Yarn is so faster than npm. We can move package manager from Npm to Yarn for JavaScript now.

Please refer to https://github.com/appleboy/npm-vs-yarn

![screen shot 2016-10-13 at 12 03 33 pm](https://cloud.githubusercontent.com/assets/21979/19338790/d7d8e17a-9151-11e6-8011-881c6f8001b2.png)

You can login as `root` or `laradock` to execute `yarn` command. 

cc @Mahmoudz @philtrep 
