### PR TITLE
use utf8 charset on nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,4 +26,5 @@ http {
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-available/*;
   open_file_cache max=100;
+  charset UTF-8;
 }


### PR DESCRIPTION
I had an issue where one of my javascript files had garbled characters at the EOF . After I set the charset to utf8 , the javascript console stopped complaining. 