### PR TITLE
Update Dockerfile

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.6
+FROM mysql:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 


### PR DESCRIPTION
Update to latest version of mysql. This will (at this time) provide 5.7.16 which will allow use of the json field type.