### PR TITLE
fix #395 adds phpunit path to non-root user's .bashrc

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -234,6 +234,16 @@ RUN if [ ${INSTALL_AEROSPIKE_EXTENSION} = false ]; then \
     rm /etc/php/7.0/cli/conf.d/aerospike.ini \
 ;fi
 
+#####################################
+# Non-root user : PHPUnit path
+#####################################
+
+# add ./vendor/bin to non-root user's bashrc (needed for phpunit)
+USER laradock
+
+RUN echo "" >> ~/.bashrc && \
+    echo 'export PATH="/var/www/vendor/bin:$PATH"' >> ~/.bashrc
+
 #
 #--------------------------------------------------------------------------
 # Final Touch


### PR DESCRIPTION
Adds /var/www/vendor/bin to $PATH in non-root user's ("laradock") .bashrc