### PR TITLE
Fix for mariadb local path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
     mariadb:
         build: ./mariadb
         volumes:
-            - mariadb
+            - mysql:/var/lib/mysql
         ports:
             - "3306:3306"
         environment:


### PR DESCRIPTION
When running docker-compose with mariadb the following message will appear:

ERROR: for mariadb  Cannot create container for service mariadb: Invalid volume spec "mariadb": Invalid volume destination path: 'mariadb' mount path must be absolute.
ERROR: Encountered errors while bringing up the project.

This commit fixes the issue.