### PR TITLE
Revert #418 and fix install yarn package management.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
         ports:
            - "2222:22"
         tty: true
-        environment:
-            - PATH=$PATH:/home/laradock/.yarn/bin:/var/www/vendor/bin:/home/laradock/.nvm/versions/node/v7.1.0/bin
 
 ### PHP-FPM Container #######################################
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -191,7 +191,7 @@ ARG INSTALL_YARN=false
 ENV INSTALL_YARN ${INSTALL_YARN}
 
 RUN if [ ${INSTALL_YARN} = true ]; then \
-    export PATH=$PATH:/home/laradock/.nvm/versions/node/v7.1.0/bin && \
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
     curl -o- -L https://yarnpkg.com/install.sh | bash && \
     echo "" >> ~/.bashrc && \
     echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> ~/.bashrc \


### PR DESCRIPTION
We can't specfic the node version on `docker-compose` file since `nvm install ${NODE_VERSION}` will install stable version of node. Maybe It will not match `v7.1.0` in the future.

![screen shot 2016-11-10 at 10 26 40 am](https://cloud.githubusercontent.com/assets/21979/20162559/de0d5518-a730-11e6-8d97-ddd8244f6ccb.png)


cc @Mahmoudz @philtrep @moxar @g0ld3lux

ref: #415 #418 #416

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>