### PR TITLE
Fixes for nginx and mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
             - applications
         volumes:
             - ./logs/nginx/:/var/log/nginx
+            - ./nginx/sites/:/etc/nginx/sites-available
         ports:
             - "80:80"
             - "443:443"

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.6
+FROM mysql:5.7
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -4,3 +4,6 @@
 # http://dev.mysql.com/doc/mysql/en/server-system-variables.html
 
 [mysql]
+
+[mysqld]
+sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,7 +3,6 @@ FROM nginx:alpine
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 
 ADD nginx.conf /etc/nginx/
-COPY sites/*.conf /etc/nginx/sites-available/
 
 ARG PHP_UPSTREAM=php-fpm
 

--- a/nginx/sites/.gitignore
+++ b/nginx/sites/.gitignore
@@ -1,0 +1,2 @@
+*.conf
+!default.conf


### PR DESCRIPTION
It seems more reasonably don't rebuild image every time when new application added, so just link its configurations as volume.

It very strange to downgrade mysql version from latest to 5.6 because it broke available databases. I offer to kill ONLY_FULL_GROUP_BY evil and to use 5.7 ;)