### PR TITLE
fix workspace load mongodb.so problem

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -125,7 +125,7 @@ ENV INSTALL_MONGO ${INSTALL_MONGO}
 RUN if [ ${INSTALL_MONGO} = true ]; then \
     # Install the mongodb extension
     pecl install mongodb && \
-    echo "extension=mongodb.so" >> /etc/php/7.0/cli/php.ini \
+    echo "extension=mongodb.so" >> /etc/php/7.0/cli/conf.d/30-mongodb.ini \
 ;fi
 
 #####################################


### PR DESCRIPTION
```
PHP Warning: PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/mongodb.so' - /usr/lib/php/20151012/mongodb.so: undefined symbol: php_json_serializable_ce in Unknown on line 0
```

Fix php warning when workspace set `INSTALL_MONGO=true` and mongodb.so can not be load.