### PR TITLE
Laradock CLI Helper allow much simple use command line tools like npm…

### DIFF
--- a/ldk
+++ b/ldk
@@ -8,6 +8,25 @@
 # Version: 0.1.0
 #####################################################
 
+command=$1
+
+
+case $command in
+    init)
+        echo "Checking latest release..."
+        if [ ! -d "${PWD}/.laradock" ];
+        then
+            mkdir .laradock
+        fi
+        release_url=`wget -qO- https://api.github.com/repos/laradock/laradock/tags | sed -n '/tarball_url/p' | head -n 1 | sed -e 's/.*tarball_url.*\(http.*\)".*/\1/'`
+        echo "Using Laradock ${release_url##*/} release."
+
+        echo "Downloading..."
+        wget -qO- $release_url | tar xz --directory=${PWD}/.laradock --strip-components=1
+        echo "Done."
+        exit 0
+esac
+
 if [ -d "${PWD}/.laradock" ];
 then
     script_dir="${PWD}/.laradock"
@@ -17,6 +36,7 @@ else
         script_dir="${PWD}/../.laradock"
     else
         echo "Warning! Laradock not found for this project."
+        echo "Maybe you want to use 'ldk init' to download and install Laradock?"
         exit 1
     fi
 fi

--- a/ldk
+++ b/ldk
@@ -1,89 +1,24 @@
 #!/bin/bash
 
-command=$1
-params=${@:2}
-cur_dir_name=${PWD##*/}
-project_dir="/var/www/$cur_dir_name"
-script=$(readlink -f "$0")
-script_dir=$(dirname $script)
+#####################################################
+# This is a starter for Laradock
+# 
+# See details on https://github.com/laradock/laradock
+# Author: Dmitry Pupinin
+# Version: 0.1.0
+#####################################################
 
-node_init="source \"\$NVM_DIR/nvm.sh\" && export PATH=\$PATH:/home/laradock/.nvm/versions/node/\$(echo \"nvm current\")/bin"
-
-help_text="Laradock CLI v0.1
-The easiest way to use tools inside 'workspace' container.
-
-Tools available:
-    artisan
-    composer
-    node
-    npm
-    nvm
-    gulp
-    bower
-    install (makes this script global)
-    run (executes shell commands)
-
-Examples (run in project's directory on the host):
-    ldk artisan make:model MyNewModel
-    ldk composer install
-    ldk run php -v
-"
-
-
-case $command in
-    install)
-        echo "Installing..."
-        if [ "$EUID" -ne 0 ]
-        then
-            echo "Failed! Be shure that you run install with 'sudo'"
-            exit 1
-        else
-            read -p "Please, choose name of symlink [ldk]: " link_name
-            if [ "$link_name" == "" ]
-            then
-                link_name="ldk"
-            fi
-            lnk="/usr/bin/$link_name"
-            if [ -L $lnk ]
-            then
-                rm $lnk
-            fi
-            ln -s `realpath $0` $lnk
-            echo "Success! Symbolic link ${lnk} created."
-            echo "Now you can go in project directory and run '$link_name artisan'"
-            exit 0
-        fi ;;
-
-    run)
-        tail="$params" ;;
-
-    artisan)
-        tail="cd ${project_dir} && ./artisan $params" ;;
-
-    composer)
-        tail="${*} --working-dir ${project_dir}" ;;
-
-    node)
-        tail="$node_init && node" ;;
-
-    npm)
-        tail="$node_init && npm --prefix=${project_dir} $params" ;;
-
-    nvm)
-        tail="$node_init && nvm $params" ;;
-
-    gulp)
-        tail="$node_init && gulp $params --cwd ${project_dir}" ;;
-
-    bower)
-        tail="$node_init && bower $params --config.cwd=${project_dir}" ;;
-
-    *)
-        echo "$help_text" ;;
-
-esac
-
-if [ "$tail" != "" ]
+if [ -d "${PWD}/.laradock" ];
 then
-    docker-compose -f $script_dir/docker-compose.yml exec --user=laradock workspace /bin/bash -c "$tail"
+    script_dir="${PWD}/.laradock"
+else
+    if [ -d "${PWD}/../.laradock" ];
+    then
+        script_dir="${PWD}/../.laradock"
+    else
+        echo "Warning! Laradock not found for this project."
+        exit 1
+    fi
 fi
+
+$script_dir/ldk-cli $*

--- a/ldk
+++ b/ldk
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+command=$1
+params=${@:2}
+cur_dir_name=${PWD##*/}
+project_dir="/var/www/$cur_dir_name"
+script=$(readlink -f "$0")
+script_dir=$(dirname $script)
+
+node_init="source \"\$NVM_DIR/nvm.sh\" && export PATH=\$PATH:/home/laradock/.nvm/versions/node/\$(echo \"nvm current\")/bin"
+
+help_text="Laradock CLI v0.1
+The easiest way to use tools inside 'workspace' container.
+
+Tools available:
+    artisan
+    composer
+    node
+    npm
+    nvm
+    gulp
+    bower
+    install (makes this script global)
+    run (executes shell commands)
+
+Examples (run in project's directory on the host):
+    ldk artisan make:model MyNewModel
+    ldk composer install
+    ldk run php -v
+"
+
+
+case $command in
+    install)
+        echo "Installing..."
+        if [ "$EUID" -ne 0 ]
+        then
+            echo "Failed! Be shure that you run install with 'sudo'"
+            exit 1
+        else
+            read -p "Please, choose name of symlink [ldk]: " link_name
+            if [ "$link_name" == "" ]
+            then
+                link_name="ldk"
+            fi
+            lnk="/usr/bin/$link_name"
+            if [ -L $lnk ]
+            then
+                rm $lnk
+            fi
+            ln -s `realpath $0` $lnk
+            echo "Success! Symbolic link ${lnk} created."
+            echo "Now you can go in project directory and run '$link_name artisan'"
+            exit 0
+        fi ;;
+
+    run)
+        tail="$params" ;;
+
+    artisan)
+        tail="cd ${project_dir} && ./artisan $params" ;;
+
+    composer)
+        tail="${*} --working-dir ${project_dir}" ;;
+
+    node)
+        tail="$node_init && node" ;;
+
+    npm)
+        tail="$node_init && npm --prefix=${project_dir} $params" ;;
+
+    nvm)
+        tail="$node_init && nvm $params" ;;
+
+    gulp)
+        tail="$node_init && gulp $params --cwd ${project_dir}" ;;
+
+    bower)
+        tail="$node_init && bower $params --config.cwd=${project_dir}" ;;
+
+    *)
+        echo "$help_text" ;;
+
+esac
+
+if [ "$tail" != "" ]
+then
+    docker-compose -f $script_dir/docker-compose.yml exec --user=laradock workspace /bin/bash -c "$tail"
+fi

--- a/ldk-cli
+++ b/ldk-cli
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+command=$1
+params=${@:2}
+cur_dir_name=${PWD##*/}
+project_dir="/var/www/$cur_dir_name"
+script=$(readlink -f "$0")
+script_dir=$(dirname $script)
+
+node_init="source \"\$NVM_DIR/nvm.sh\" && export PATH=\$PATH:/home/laradock/.nvm/versions/node/\$(echo \"nvm current\")/bin"
+
+help_text="Laradock CLI v0.1
+The easiest way to use tools inside 'workspace' container.
+
+Tools available:
+    artisan
+    composer
+    node
+    npm
+    nvm
+    gulp
+    bower
+    install (makes this script global)
+    run (runs any available system command)
+
+Examples (do it inside project's directory):
+    ldk artisan make:model MyNewModel
+    ldk composer install
+    ldk run php -v
+"
+
+
+case $command in
+    install)
+        echo "Installing..."
+        if [ "$EUID" -ne 0 ]
+        then
+            echo "Failed! Be shure that you run install with 'sudo'"
+            exit 1
+        else
+            if [ -f /usr/bin/ldk ]
+            then
+                rm /usr/bin/ldk
+            fi
+            cp "$script_dir/ldk" /usr/bin/ldk
+            echo "Success! Laradock cli starter installed."
+            echo "Now you can go in project directory and run 'ldk artisan'"
+            exit 0
+        fi ;;
+
+    run)
+        tail="$params" ;;
+
+    artisan)
+        tail="cd ${project_dir} && ./artisan $params" ;;
+
+    composer)
+        tail="${*} --working-dir ${project_dir}" ;;
+
+    node)
+        tail="$node_init && node" ;;
+
+    npm)
+        tail="$node_init && npm --prefix=${project_dir} $params" ;;
+
+    nvm)
+        tail="$node_init && nvm $params" ;;
+
+    gulp)
+        tail="$node_init && gulp $params --cwd ${project_dir}" ;;
+
+    bower)
+        tail="$node_init && bower $params --config.cwd=${project_dir}" ;;
+
+    *)
+        echo "$help_text" ;;
+
+esac
+
+if [ "$tail" != "" ]
+then
+    docker-compose -f $script_dir/docker-compose.yml exec --user=laradock workspace /bin/bash -c "$tail"
+fi

--- a/ldk-cli
+++ b/ldk-cli
@@ -80,5 +80,5 @@ esac
 
 if [ "$tail" != "" ]
 then
-    docker-compose -f $script_dir/docker-compose.yml exec --user=laradock workspace /bin/bash -c "$tail"
+    cd ${script_dir} && docker-compose exec --user=laradock workspace /bin/bash -c "$tail"
 fi

--- a/ldk-cli
+++ b/ldk-cli
@@ -21,6 +21,7 @@ Tools available:
     gulp
     bower
     install (makes this script global)
+    init (download latest laradock release into current project)
     run (runs any available system command)
 
 Examples (do it inside project's directory):


### PR DESCRIPTION
Laradock CLI Helper allow much simple use command line tools (from container) like npm, composer, gulp, bower etc. with your projects.

You need to use multisites configuration like (structure inside container after linking):
/var/www/project1
/var/www/project2
...

**Step 1** (install soft link in PATH folder):
cd laradock
sudo ldk install

**Step 2** (using):
cd ~/MyProjects/project1
ldk composer install   // Use composer to install dependencies
ldk composer <any_composer_command>
ldk artisan <any_artisan_command>
ldk npm <any_command>
ldk bower <any_command>
ldk gulp <any_command>

PS: You can rename script as you like.