### PR TITLE
Support specific version of yarn.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
                 - PUID=1000
                 - PGID=1000
                 - NODE_VERSION=stable
+                - YARN_VERSION=latest
                 - TZ=UTC
         volumes_from:
             - applications

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -189,10 +189,16 @@ USER laradock
 
 ARG INSTALL_YARN=false
 ENV INSTALL_YARN ${INSTALL_YARN}
+ARG YARN_VERSION=latest
+ENV YARN_VERSION ${YARN_VERSION}
 
 RUN if [ ${INSTALL_YARN} = true ]; then \
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
-    curl -o- -L https://yarnpkg.com/install.sh | bash && \
+    if [ ${YARN_VERSION} = "latest" ]; then \
+        curl -o- -L https://yarnpkg.com/install.sh | bash; \
+    else \
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}; \
+    fi && \
     echo "" >> ~/.bashrc && \
     echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> ~/.bashrc \
 ;fi


### PR DESCRIPTION
Add `YARN_VERSION` args

Yarn `latest` version:

![screen shot 2016-12-16 at 9 32 48 am](https://cloud.githubusercontent.com/assets/21979/21248559/d07f8822-c372-11e6-8138-1851ee63579f.png)

Yarn `0.17.8` version

![screen shot 2016-12-16 at 9 32 00 am](https://cloud.githubusercontent.com/assets/21979/21248558/d07e88be-c372-11e6-9cdc-1b5ab94ea178.png)

reference guide: https://yarnpkg.com/en/docs/install#alternatives-tab

cc @philtrep @Mahmoudz 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>