### PR TITLE
Fix syntax error php-fpm docokerfile

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -44,8 +44,8 @@ ARG INSTALL_SOAP=false
 RUN if [ ${INSTALL_SOAP} = true ]; then \
     # Install the soap extension
     apt-get -y update && \
-    apt-get -y install libxml2-dev && \ 
-    docker-php-ext-install soap && \
+    apt-get -y install libxml2-dev && \
+    docker-php-ext-install soap \
 ;fi
 
 #####################################

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -45,7 +45,7 @@ ARG INSTALL_SOAP=false
 RUN if [ ${INSTALL_SOAP} = true ]; then \
     # Install the soap extension
     apt-get -y update && \
-    apt-get -y install libxml2-dev && \ 
+    apt-get -y install libxml2-dev && \
     docker-php-ext-install soap \
 ;fi
 


### PR DESCRIPTION
Fix the syntax error `/bin/sh: 1: Syntax error: ";" unexpected` for php-fpm dokcerfile on build image.