### PR TITLE
Add `art` alias for `php artisan` - like homestead

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -267,7 +267,15 @@ USER laradock
 
 RUN echo "" >> ~/.bashrc && \
     echo 'export PATH="/var/www/vendor/bin:$PATH"' >> ~/.bashrc
+	
+#####################################
+# Laravel Artisan Alias
+#####################################
+USER root
 
+RUN echo "" >> ~/.bashrc && \
+	echo 'alias art="php artisan"' >> ~/.bashrc
+	
 #
 #--------------------------------------------------------------------------
 # Final Touch


### PR DESCRIPTION
Since moving from Homestead to Laradock this is definitely something that I have missed, so I've added it to the Dockerfile.