### PR TITLE
Added service container for Selenium standalone with Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Laradock is configured to run Laravel Apps by default, and it can be modified to
 		- [Use phpMyAdmin](#Use-phpMyAdmin)
 		- [Use pgAdmin](#Use-pgAdmin)
 		- [Use ElasticSearch](#Use-ElasticSearch)
+		- [Use Selenium](#Use-Selenium)
 	- [CodeIgniter](#CodeIgniter):
 		- [Install CodeIgniter](#Install-CodeIgniter)
 	- [Misc](#Misc)
@@ -1058,7 +1059,17 @@ docker exec {container-name} /usr/share/elasticsearch/bin/plugin install delete-
 docker restart {container-name}
 ```
 
+<br>
+<a name="Use-Selenium"></a>
+### Use Selenium
 
+1 - Run the Selenium Container (`selenium`) with the `docker-compose up` command. Example:
+
+```bash
+docker-compose up -d selenium
+```
+
+2 - Open your browser and visit the localhost on port **4444** at the following URL:  `http://localhost:4444/wd/hub`
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,6 +324,13 @@ services:
         links:
             - php-fpm
 
+### Selenium Container #########################################
+
+    selenium:
+        build: ./selenium
+        ports:
+            - "4444:4444"
+
 ### Volumes Setup ###########################################
 
 volumes:

--- a/selenium/Dockerfile
+++ b/selenium/Dockerfile
@@ -1,0 +1,5 @@
+FROM selenium/standalone-chrome
+
+MAINTAINER Edmund Luong <edmundvmluong@gmail.com>
+
+EXPOSE 4444


### PR DESCRIPTION
Resolves #356 

Added Selenium using the official Selenium docker images from https://github.com/SeleniumHQ/docker-selenium

The Selenium server is served on port 4444