### PR TITLE
Fix bug on mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
     mariadb:
         build: ./mariadb
         volumes:
-            - mysql:/var/lib/mysql
+            - mariadb:/var/lib/mysql
         ports:
             - "3306:3306"
         environment:


### PR DESCRIPTION
Bug on Docker for Mac when we change the database from mysql to mariadb.
#448 .

Maybe It is not a perfect fix. This fix will not share the same mysql volume, means we could not change database directly. We have to import the database to both database. But it will fix the Bug . Wish for better solution

