### PR TITLE
Fix Workspace Cron Permissions

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -80,6 +80,7 @@ RUN if [ ${COMPOSER_GLOBAL_INSTALL} = true ]; then \
 USER root
 
 COPY ./crontab /etc/cron.d
+RUN chmod -R 644 /etc/cron.d
 
 #####################################
 # xDebug:


### PR DESCRIPTION
When I submitted #538 it looks like I overlooked the crontab file
permissions for the Laradock user. This change ensure that all
crons added during build are set to the correct permission level.