### PR TITLE
Fixing issue #568

### DIFF
--- a/nginx/sites/default.conf
+++ b/nginx/sites/default.conf
@@ -15,6 +15,8 @@ server {
         try_files $uri /index.php =404;
         fastcgi_pass php-upstream;
         fastcgi_index index.php;
+        fastcgi_buffers 16 16k; 
+        fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
     }


### PR DESCRIPTION
Increasing buffer sizes to work with applications like react/babel.

Fixed tested by executing the following:
1. Built the Nginx workspace - successful
2. Ran the containers Nginx with the same app that was throwing the error - success
3. Ran the application with requests to servers for 10 minutes - no errors found.
