### PR TITLE
xdebugPhpFpm permission denied fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,8 @@ To control the behavior of xDebug (in the `php-fpm` Container), you can run the 
 - Start xDebug by default: `./xdebugPhpFpm start`.
 - See the status: `./xdebugPhpFpm status`.
 
+Note: If `./xdebugPhpFpm` doesnt execute and gives `Permission Denied` error the problem can be that file `xdebugPhpFpm` doesnt have execution access.
+  This can be fixed by running `chmod` command  with desired access permissions.
 
 
 

--- a/README.md
+++ b/README.md
@@ -794,8 +794,7 @@ To control the behavior of xDebug (in the `php-fpm` Container), you can run the 
 - Start xDebug by default: `./xdebugPhpFpm start`.
 - See the status: `./xdebugPhpFpm status`.
 
-Note: If `./xdebugPhpFpm` doesnt execute and gives `Permission Denied` error the problem can be that file `xdebugPhpFpm` doesnt have execution access.
-  This can be fixed by running `chmod` command  with desired access permissions.
+Note: If `./xdebugPhpFpm` doesn't execute and gives `Permission Denied` error the problem can be that file `xdebugPhpFpm` doesn't have execution access. This can be fixed by running `chmod` command  with desired access permissions.
 
 
 


### PR DESCRIPTION
* xdebugPhpFpm might not have execution access when cloned. This
addition to readme helps tell the user why he got Permission Denied and
what can be done to fix it.