### PR TITLE
Fix Caddy volumes to persist SSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,6 +287,7 @@ services:
         volumes:
             - ./caddy/Caddyfile:/etc/Caddyfile
             - ./logs/caddy:/var/log/caddy
+            - caddy:/root/.caddy
         links:
             - php-fpm
 


### PR DESCRIPTION
I'm blaming commit https://github.com/laradock/laradock/commit/380eef5fd954f3066ad0df6a6e613302ba0edf1a for breaking this functionality.