### PR TITLE
Fixed memcached for php5.6

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -101,7 +101,7 @@ RUN if [ ${INSTALL_BCMATH} = true ]; then \
 ARG INSTALL_MEMCACHED=false
 RUN if [ ${INSTALL_MEMCACHED} = true ]; then \
     # Install the php memcached extension
-    pecl install memcached && \
+    pecl install memcached-2.2.0 && \
     docker-php-ext-enable memcached \
 ;fi
 


### PR DESCRIPTION
```
Step 15/32 : RUN if [ ${INSTALL_MEMCACHED} = true ]; then     pecl install memcached &&     docker-php-ext-enable memcached ;fi
 ---> Running in b43e2e6b07f6
pecl/memcached requires PHP (version >= 7.0.0), installed version is 5.6.24
pecl/memcached can optionally use PHP extension "igbinary" (version >= 2.0)
pecl/memcached can optionally use PHP extension "msgpack" (version >= 2.0)
No valid packages found
install failed
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c if [ ${INSTALL_MEMCACHED} = true ]; then     pecl install memcached &&     docker-php-ext-enable memcached ;fi' returned a non-zero code: 1
```