### PR TITLE
Adding DNS Plugins - Issue

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -4,6 +4,10 @@ root /var/www/public
 fastcgi / php-fpm:9000 php {
     index index.php
 }
+
+# To handle .html extensions with laravel change ext to
+# ext / .html
+
 rewrite {
     r .*
     ext /
@@ -16,3 +20,9 @@ errors /var/log/caddy/error.log
 # Uncomment to enable TLS (HTTPS)
 # Change the first list to listen on port 443 when enabling TLS
 #tls self_signed
+
+# To use Lets encrpt tls with a DNS provider uncomment these
+# lines and change the provider as required
+#tls {
+#  dns cloudflare
+#}

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 MAINTAINER Eric Pfeiffer <computerfr33k@users.noreply.github.com>
 
-ENV caddy_version=0.9.3
+ENV caddy_version=0.9.5
 
 LABEL caddy_version="$caddy_version" architecture="amd64"
 
@@ -12,9 +12,9 @@ RUN apk update \
 
 RUN curl --silent --show-error --fail --location \
         --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-        "https://github.com/mholt/caddy/releases/download/v$caddy_version/caddy_linux_amd64.tar.gz" \
-        | tar --no-same-owner -C /usr/bin/ -xz caddy_linux_amd64 \
-    && mv /usr/bin/caddy_linux_amd64 /usr/bin/caddy \
+        "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cloudflare%2Cdigitalocean%2Cdnsimple%2Cdyn%2Cgooglecloud%2Clinode%2Croute53" \
+        | tar --no-same-owner -C /usr/bin/ -xz caddy \
+    && mv /usr/bin/caddy /usr/bin/caddy \
     && chmod 0755 /usr/bin/caddy
 
 EXPOSE 80 443 2015


### PR DESCRIPTION
Pull request in reference to [#623](https://github.com/laradock/laradock/issues/623)

This updates the download URL to include the DNS provider plugins so that we can use letsencrypt on our local environment. 

One thing to note, the version parameter is not currently available as part of the dynamic download URL so this may need looking at in the future. As of this commit it will use the latest version.