### PR TITLE
workaround for 'Xdebug breaks on access to class static property'

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -55,8 +55,11 @@ RUN if [ ${INSTALL_SOAP} = true ]; then \
 ARG INSTALL_XDEBUG=false
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Install the xdebug extension
-    pecl install xdebug && \
-    docker-php-ext-enable xdebug \
+    # pecl install xdebug && docker-php-ext-enable xdebug \
+    # workaround for https://github.com/docker-library/php/issues/133
+    #     - Xdebug breaks on access to class static property
+    apt-get install -y php5-xdebug && \
+	echo "zend_extension=/usr/lib/php5/20131226/xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
 ;fi
 
 # Copy xdebug configration for remote debugging


### PR DESCRIPTION
see https://github.com/docker-library/php/issues/133