### PR TITLE
fix selenium - mount /dev/shm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -336,6 +336,9 @@ services:
         build: ./selenium
         ports:
             - "4444:4444"
+        volumes:
+            # see https://github.com/SeleniumHQ/docker-selenium#running-the-images
+            - /dev/shm:/dev/shm
 
 ### Volumes Setup ###########################################
 


### PR DESCRIPTION
see https://github.com/SeleniumHQ/docker-selenium#running-the-images
> When executing docker run for an image with chrome browser please add volume mount -v /dev/shm:/dev/shm to use the host's shared memory.