### PR TITLE
Refine container name retrieval

### DIFF
--- a/xdebugPhpFpm
+++ b/xdebugPhpFpm
@@ -4,7 +4,7 @@
 
 
 # Grab full name of php-fpm container
-PHP_FPM_CONTAINER=$(docker-compose ps | grep php-fpm | cut -d " " -f 1)
+PHP_FPM_CONTAINER=$(docker ps | grep php-fpm | awk '{print $1}')
 
 
 # Grab OS type


### PR DESCRIPTION
Changed to `docker ps` because it word wraps.  `docker-compose ps` will create a newline if text is too long in a small terminal window.  Also `awk` represents tokens better than ones cut with a " " delimiter.