### PR TITLE
re-added .gitignore for nginx dir, still do not want configs in git

### DIFF
--- a/nginx/sites/.gitignore
+++ b/nginx/sites/.gitignore
@@ -1,0 +1,2 @@
+*.conf
+!default.conf


### PR DESCRIPTION
It seems weird to now include the conf files in git... I couldn't really find where this got removed, but I feel it still needs to be there.