### PR TITLE
Fixed path variable for windows users

### DIFF
--- a/env-example
+++ b/env-example
@@ -1,3 +1,6 @@
+# Fix for windows users to make sure the application path works.
+COMPOSE_CONVERT_WINDOWS_PATHS=1
+
 ### Application
 # Point to your application code, wish should be available at `/var/www`
 


### PR DESCRIPTION
apparently as can be seen here: https://github.com/laradock/laradock/issues/696#issuecomment-288020883

I removed the windows path variable fix which broke something for windows users. This commit fixes that.