### PR TITLE
:sparkles: Sending logs to docker `stdout` and `stderr`.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,8 +19,8 @@ http {
   client_max_body_size 20M;
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
-  access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
+  access_log /dev/stdout;
+  error_log /dev/stderr;
   gzip on;
   gzip_disable "msie6";
   


### PR DESCRIPTION
Docs have this:

> The NGINX Log file is stored in the logs/nginx directory.
> However to view the logs of all the other containers (MySQL, PHP-FPM,…) you can run this:
> ...

But no reason as to _why_ the nginx logs don't use docker's logging. `docker logs -f nginx` seems easy enough. Unless there's a reason I'm missing for logging to the host's filesystem?

