### PR TITLE
remove /Volumes and /private entries for d4m-nfs from docs

### DIFF
--- a/DOCUMENTATION/_settings/content/documentation/index.md
+++ b/DOCUMENTATION/_settings/content/documentation/index.md
@@ -1375,8 +1375,6 @@ git clone https://github.com/IFSight/d4m-nfs ~/d4m-nfs
 
 ```txt
 /Users:/Users
-/Volumes:/Volumes
-/private:/private
 ```
 
 5) Create (or edit) the file `/etc/exports`, make sure it exists and is empty. (There may be collisions if you come from Vagrant or if you already executed the `d4m-nfs.sh` script before).

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -1423,8 +1423,6 @@ e) set it to <code>true</code></p>
 <p>4) Create (or edit) the file <code>~/d4m-nfs/etc/d4m-nfs-mounts.txt</code>, and write the follwing configuration in it:</p>
 
 <pre><code class="language-txt">/Users:/Users
-/Volumes:/Volumes
-/private:/private
 </code></pre>
 
 <p>5) Create (or edit) the file <code>/etc/exports</code>, make sure it exists and is empty. (There may be collisions if you come from Vagrant or if you already executed the <code>d4m-nfs.sh</code> script before).</p>

--- a/docs/documentation/index.xml
+++ b/docs/documentation/index.xml
@@ -1126,8 +1126,6 @@ e) set it to &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;
 &lt;p&gt;4) Create (or edit) the file &lt;code&gt;~/d4m-nfs/etc/d4m-nfs-mounts.txt&lt;/code&gt;, and write the follwing configuration in it:&lt;/p&gt;
 
 &lt;pre&gt;&lt;code class=&#34;language-txt&#34;&gt;/Users:/Users
-/Volumes:/Volumes
-/private:/private
 &lt;/code&gt;&lt;/pre&gt;
 
 &lt;p&gt;5) Create (or edit) the file &lt;code&gt;/etc/exports&lt;/code&gt;, make sure it exists and is empty. (There may be collisions if you come from Vagrant or if you already executed the &lt;code&gt;d4m-nfs.sh&lt;/code&gt; script before).&lt;/p&gt;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1828,8 +1828,6 @@ e) set it to <code>true</code></p>
 <p>4) Create (or edit) the file <code>~/d4m-nfs/etc/d4m-nfs-mounts.txt</code>, and write the follwing configuration in it:</p>
 
 <pre><code class="language-txt">/Users:/Users
-/Volumes:/Volumes
-/private:/private
 </code></pre>
 
 <p>5) Create (or edit) the file <code>/etc/exports</code>, make sure it exists and is empty. (There may be collisions if you come from Vagrant or if you already executed the <code>d4m-nfs.sh</code> script before).</p>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1540,8 +1540,6 @@ e) set it to &lt;code&gt;true&lt;/code&gt;&lt;/p&gt;
 &lt;p&gt;4) Create (or edit) the file &lt;code&gt;~/d4m-nfs/etc/d4m-nfs-mounts.txt&lt;/code&gt;, and write the follwing configuration in it:&lt;/p&gt;
 
 &lt;pre&gt;&lt;code class=&#34;language-txt&#34;&gt;/Users:/Users
-/Volumes:/Volumes
-/private:/private
 &lt;/code&gt;&lt;/pre&gt;
 
 &lt;p&gt;5) Create (or edit) the file &lt;code&gt;/etc/exports&lt;/code&gt;, make sure it exists and is empty. (There may be collisions if you come from Vagrant or if you already executed the &lt;code&gt;d4m-nfs.sh&lt;/code&gt; script before).&lt;/p&gt;


### PR DESCRIPTION
Author of d4m-nfs here. We have run into quite a few people on our d4m-nfs issue queue that appear to have issue that might of been caused by your documentation. Please either accept this PR or update your docs. Thanks!

The /Volumes entry is not good with how NFS exports hierarchically.
The /private entry should not just be included by default.

https://github.com/IFSight/d4m-nfs/commit/45f1628be62f91c5c7aaff9a97de931f5b5679fb