### PR TITLE
Fixing can't login to PHPMyAdmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,6 +392,7 @@ services:
         - "${PMA_DB_ENGINE}"
       networks:
         - frontend
+        - backend
 
 ### Adminer Container ####################################
 


### PR DESCRIPTION
fix #754, login to PHPMyAdmin get "#2005 - Unknown MySQL server host 'mysql' (-2)" error.