### PR TITLE
Fixing soap already loaded warning in workspace

### DIFF
--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -60,8 +60,7 @@ RUN if [ ${INSTALL_SOAP} = true ]; then \
   # Install the PHP SOAP extension
   apt-get -y update && \
   add-apt-repository -y ppa:ondrej/php && \
-  apt-get -y install libxml2-dev php7.0-soap && \
-  echo "extension=soap.so" >> /etc/php/7.0/cli/conf.d/40-soap.ini \
+  apt-get -y install libxml2-dev php7.0-soap \
 ;fi
 
 #####################################


### PR DESCRIPTION
In the workspace container, when looking in the following folder: `/etc/php/7.0/cli/conf.d/`, these (relevant: `ls | grep soap`) files are installed:

**20-soap.ini**
```
; configuration for php soap module
; priority=20
extension=soap.so
```

**40-soap.ini**
```
extension=soap.so
```

This'll load the extension twice, I assume. I'm however not sure what happened that this warning is now being displayed.

This pull request fixes #787 