### PR TITLE
Fixing php fpm ghostscript

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -202,7 +202,7 @@ RUN if [ ${INSTALL_INTL} = true ]; then \
 #####################################
 
 ARG INSTALL_GHOSTSCRIPT=false
-RUN if [ ${GHOSTSCRIPT} = true ]; then \
+RUN if [ ${INSTALL_GHOSTSCRIPT} = true ]; then \
     # Install the ghostscript extension for PDF editing
     apt-get update && \
     apt-get install -y poppler-utils ghostscript \

--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -287,7 +287,7 @@ RUN if [ ${INSTALL_INTL} = true ]; then \
 #####################################
 
 ARG INSTALL_GHOSTSCRIPT=false
-RUN if [ ${GHOSTSCRIPT} = true ]; then \
+RUN if [ ${INSTALL_GHOSTSCRIPT} = true ]; then \
     # Install the ghostscript extension
     # for PDF editing
     apt-get -y update \

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -207,7 +207,7 @@ RUN if [ ${INSTALL_INTL} = true ]; then \
 #####################################
 
 ARG INSTALL_GHOSTSCRIPT=false
-RUN if [ ${GHOSTSCRIPT} = true ]; then \
+RUN if [ ${INSTALL_GHOSTSCRIPT} = true ]; then \
     # Install the ghostscript extension
     # for PDF editing
     apt-get -y update \


### PR DESCRIPTION
fix unexpected message "/bin/sh: 1: [: =: unexpected operator", #798.