### PR TITLE
Fix small typo ‘Giude’ -> ‘Guide’

### DIFF
--- a/DOCUMENTATION/config.toml
+++ b/DOCUMENTATION/config.toml
@@ -62,7 +62,7 @@ googleAnalytics = "UA-37514928-9"
 	weight = 3
 
 [[menu.main]]
-	name   = "Giudes"
+	name   = "Guides"
 	url    = "guides/"
 	weight = 4
 


### PR DESCRIPTION
Fix a small typo in the documentation.