### PR TITLE
Run apt-get update before installing intl extension

### DIFF
--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -277,7 +277,8 @@ RUN if [ ${MSSQL} = true ]; then \
 ARG INSTALL_INTL=false
 RUN if [ ${INSTALL_INTL} = true ]; then \
     # Install intl and requirements
-    apt-get install -y zlib1g-dev libicu-dev g++ && \
+    apt-get -y update \
+    && apt-get install -y zlib1g-dev libicu-dev g++ && \
     docker-php-ext-configure intl && \
     docker-php-ext-install intl \
 ;fi


### PR DESCRIPTION
Fixes the "unable to locate package libicu-dev" when enabling the INSTALL_INTL option.