### PR TITLE
Fix git's BUG & add plugin

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -8,11 +8,11 @@ LABEL caddy_version="$caddy_version" architecture="amd64"
 
 RUN apk update \
     && apk upgrade \
-    && apk add tar curl
+    && apk add tar curl git
 
 RUN curl --silent --show-error --fail --location \
         --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-        "https://caddyserver.com/download/linux/amd64?plugins=http.cgi,http.filemanager,http.git,tls.dns.cloudflare,tls.dns.digitalocean,tls.dns.dnsimple,tls.dns.dyn,tls.dns.googlecloud,tls.dns.linode,tls.dns.route53" \
+        "https://caddyserver.com/download/linux/amd64?plugins=http.cgi,http.cors,http.expires,http.filemanager,http.git,http.ipfilter,http.realip,tls.dns.cloudflare,tls.dns.digitalocean,tls.dns.dnspod,tls.dns.dyn,tls.dns.googlecloud,tls.dns.linode,tls.dns.namecheap,tls.dns.ovh,tls.dns.route53,tls.dns.vultr" \
         | tar --no-same-owner -C /usr/bin/ -xz caddy \
     && mv /usr/bin/caddy /usr/bin/caddy \
     && chmod 0755 /usr/bin/caddy


### PR DESCRIPTION
1. Repair git can not synchronize the BUG.
2. Increase the CDN query real IP, cross-domain request plugin.

you can use git  xxx.com  to  sync code in caddy.

Next：  I will  use  env   for  caddy.   