### PR TITLE
Fixing soap being loaded twice

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -62,8 +62,7 @@ RUN if [ ${INSTALL_SOAP} = true ]; then \
   # Install the PHP SOAP extension
   apt-get -y update && \
   add-apt-repository -y ppa:ondrej/php && \
-  apt-get -y install libxml2-dev php5.6-soap && \
-  echo "extension=soap.so" >> /etc/php/5.6/cli/conf.d/40-soap.ini \
+  apt-get -y install libxml2-dev php5.6-soap \
 ;fi
 
 #####################################


### PR DESCRIPTION
When using PHP 5.6 for the workspace container, SOAP is being loaded twice.

Before:
```shell
root@fbda31f71612:/var/www# php -v
PHP Warning:  Module 'soap' already loaded in Unknown on line 0
PHP 5.6.30-10+deb.sury.org~xenial+2 (cli)
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
```

After:

```shell
root@7d56f79104b4:/var/www# php -v
PHP 5.6.30-10+deb.sury.org~xenial+2 (cli)
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
```

It's still working:

```shell
root@7d56f79104b4:/var/www# php -i | grep soap
/etc/php/5.6/cli/conf.d/20-soap.ini,
soap
soap.wsdl_cache => 1 => 1
soap.wsdl_cache_dir => /tmp => /tmp
soap.wsdl_cache_enabled => 1 => 1
soap.wsdl_cache_limit => 5 => 5
soap.wsdl_cache_ttl => 86400 => 86400
root@7d56f79104b4:/var/www#
```

This fixes issue #748.