### PR TITLE
Add apt update to intl install

### DIFF
--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -212,6 +212,7 @@ RUN if [ ${INSTALL_TOKENIZER} = true ]; then \
 ARG INSTALL_INTL=false
 RUN if [ ${INSTALL_INTL} = true ]; then \
     # Install intl and requirements
+    apt-get -y update && \
     apt-get install -y zlib1g-dev libicu-dev g++ && \
     docker-php-ext-configure intl && \
     docker-php-ext-install intl \


### PR DESCRIPTION
Adding `apt-get update` to fix the INTL installation.

This pull request fixes issue #847.