### PR TITLE
Locking Adminer to stable version

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -718,6 +718,7 @@ docker-compose up -d adminer
 
 2 - Open your browser and visit the localhost on port **8080**:  `http://localhost:8080`
 
+**Note:** We've locked Adminer to version 4.3.0 as at the time of writing [it contained a major bug](https://sourceforge.net/p/adminer/bugs-and-features/548/) preventing PostgreSQL users from logging in. If that bug is fixed (or if you're not using PostgreSQL) feel free to set Adminer to the latest version within [the Dockerfile](https://github.com/laradock/laradock/blob/master/adminer/Dockerfile#L1): `FROM adminer:latest`
 
 
 

--- a/adminer/Dockerfile
+++ b/adminer/Dockerfile
@@ -1,4 +1,7 @@
-FROM adminer:latest
+FROM adminer:4.3.0
+
+# Version 4.3.1 contains PostgreSQL login errors. See docs.
+# See https://sourceforge.net/p/adminer/bugs-and-features/548/
 
 MAINTAINER Patrick Artounian <partounian@gmail.com>
 


### PR DESCRIPTION
Locked Adminer to version 4.3.0 as [it contained a major bug](https://sourceforge.net/p/adminer/bugs-and-features/548/) preventing PostgreSQL users from logging in.

Made a note explaining the issue in the docs as well.

This closes issue #813.