### PR TITLE
Updating workspace to use latest base image

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -12,7 +12,7 @@
 # Note: Base Image name format {image-tag}-{php-version}
 #
 
-FROM laradock/workspace:1.7-56
+FROM laradock/workspace:1.8-56
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -12,7 +12,7 @@
 # Note: Base Image name format {image-tag}-{php-version}
 #
 
-FROM laradock/workspace:1.7-70
+FROM laradock/workspace:1.8-70
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 


### PR DESCRIPTION
The [Workspace Dockerfile for PHP version 7.1](https://github.com/laradock/laradock/blob/master/workspace/Dockerfile-71#L15) is using the 1.8 version of the base image, so should the others? Changed the numbers accordingly.