### PR TITLE
Upgrading sqlsrv to version without error

### DIFF
--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -273,8 +273,8 @@ RUN if [ ${MSSQL} = true ]; then \
     # extensions:
     #####################################
 
-    pecl install sqlsrv-4.0.6 && \
-    pecl install pdo_sqlsrv-4.0.6 && \
+    pecl install sqlsrv-4.1.7preview && \
+    pecl install pdo_sqlsrv-4.1.7preview && \
 
     #####################################
     # Set locales for the container


### PR DESCRIPTION
Upgrading the sqlsrv version to resolve the `Undefined class constant 'SQLSRV_ATTR_FETCHES_NUMERIC_TYPE'` error, as discussed in #843.