### PR TITLE
Add sqlsrv to php-fpm php71

### DIFF
--- a/php-fpm/Dockerfile-70
+++ b/php-fpm/Dockerfile-70
@@ -292,8 +292,8 @@ RUN if [ ${MSSQL} = true ]; then \
 ARG INSTALL_INTL=false
 RUN if [ ${INSTALL_INTL} = true ]; then \
     # Install intl and requirements
-    apt-get -y update \
-    && apt-get install -y zlib1g-dev libicu-dev g++ && \
+    apt-get -y update && \
+    apt-get install -y zlib1g-dev libicu-dev g++ && \
     docker-php-ext-configure intl && \
     docker-php-ext-install intl \
 ;fi

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -202,7 +202,7 @@ RUN if [ ${INSTALL_MYSQLI} = true ]; then \
 
 ARG INSTALL_TOKENIZER=false
 RUN if [ ${INSTALL_TOKENIZER} = true ]; then \
-     docker-php-ext-install tokenizer \
+    docker-php-ext-install tokenizer \
 ;fi
 
 #####################################

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -206,6 +206,86 @@ RUN if [ ${INSTALL_TOKENIZER} = true ]; then \
 ;fi
 
 #####################################
+# SQL SERVER:
+#####################################
+
+ARG MSSQL=false
+RUN if [ ${MSSQL} = true ]; then \
+
+    #####################################
+    # Install Depenencies:
+    #####################################
+        apt-get update && \
+        apt-get install -y --force-yes wget apt-transport-https curl freetds-common php5-odbc libsybdb5 freetds-bin unixodbc unixodbc-dev php5-sybase && \
+
+    #####################################
+    #  The following steps were taken from
+    #  Microsoft's github account:
+    #  https://github.com/Microsoft/msphpsql/wiki/Dockerfile-for-getting-pdo_sqlsrv-for-PHP-7.0-on-Debian-in-3-ways
+    #####################################
+
+    # Add PHP 7 repository
+    # for Debian jessie
+    # And System upgrade
+        echo "deb http://packages.dotdeb.org jessie all" \
+        | tee /etc/apt/sources.list.d/dotdeb.list \
+        && wget -qO- https://www.dotdeb.org/dotdeb.gpg \
+        | apt-key add - \
+        && apt-get update \
+        && apt-get upgrade -qq && \
+
+    # Install UnixODBC
+    # Compile odbc_config as it is not part of unixodbc package
+        apt-get install -y whiptail \
+        unixodbc libgss3 odbcinst devscripts debhelper dh-exec dh-autoreconf libreadline-dev libltdl-dev \
+        && dget -u -x http://http.debian.net/debian/pool/main/u/unixodbc/unixodbc_2.3.1-3.dsc \
+        && cd unixodbc-*/ \
+        && dpkg-buildpackage -uc -us -B -d \
+        && cp -v ./exe/odbc_config /usr/local/bin/ && \
+
+    # Fake uname for install.sh
+        printf '#!/bin/bash\nif [ "$*" == "-p" ]; then echo "x86_64"; else /bin/uname "$@"; fi' \
+        | tee /usr/local/bin/uname \
+        && chmod +x /usr/local/bin/uname && \
+
+    # Microsoft ODBC Driver 13 for Linux
+    # Note: There's a copy of this tar on my hubiC
+        wget -nv -O msodbcsql-13.0.0.0.tar.gz \
+        "https://meetsstorenew.blob.core.windows.net/contianerhd/Ubuntu%2013.0%20Tar/msodbcsql-13.0.0.0.tar.gz?st=2016-10-18T17%3A29%3A00Z&se=2022-10-19T17%3A29%3A00Z&sp=rl&sv=2015-04-05&sr=b&sig=cDwPfrouVeIQf0vi%2BnKt%2BzX8Z8caIYvRCmicDL5oknY%3D" \
+        && tar -xf msodbcsql-13.0.0.0.tar.gz \
+        && cd msodbcsql-*/ \
+        && ldd lib64/libmsodbcsql-13.0.so.0.0 \
+        && ./install.sh install --accept-license \
+        && ls -l /opt/microsoft/msodbcsql/ \
+        && odbcinst -q -d -n "ODBC Driver 13 for SQL Server" \
+
+    #####################################
+    # Install pdo_dblib
+    #####################################
+
+    && docker-php-ext-install pdo \
+    && docker-php-ext-configure pdo_dblib --with-libdir=/lib/x86_64-linux-gnu \
+    && docker-php-ext-install pdo_dblib \
+    && docker-php-ext-enable pdo_dblib && \
+
+    #####################################
+    # Install sqlsrv y pdo_sqlsrv
+    # extensions:
+    #####################################
+
+    pecl install sqlsrv-4.1.7preview && \
+    pecl install pdo_sqlsrv-4.1.7preview && \
+
+    #####################################
+    # Set locales for the container
+    #####################################
+
+    apt-get install -y locales \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
+;fi
+
+#####################################
 # Human Language and Character Encoding Support:
 #####################################
 


### PR DESCRIPTION
Adding sqlsrv to php-fpm PHP71 Dockerfile as discussed in #843. 
Also, to streamline the Dockerfiles to be able to merge them in the future, as discussed in #811