### PR TITLE
Fix CI build forget update PHP_VERSION in .env

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -6,6 +6,7 @@ set -e
 #### Build the Docker Images
 if [ -n "${PHP_VERSION}" ]; then
     cp env-example .env
+    sed -i -- "s/PHP_VERSION=.*/PHP_VERSION=${PHP_VERSION}/g" .env
     sed -i -- 's/=false/=true/g' .env
     cat .env
     docker-compose build


### PR DESCRIPTION
Travis-CI at 5.6, 7.0 build job, used default PHP_VERSION=71 set in .env, is wrong.