### PR TITLE
Fixing V8JS

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -300,23 +300,6 @@ RUN if [ ${INSTALL_AEROSPIKE_EXTENSION} = false ]; then \
 ;fi
 
 #####################################
-# PHP V8JS:
-#####################################
-USER root
-
-ARG INSTALL_V8JS_EXTENSION=false
-ENV INSTALL_V8JS_EXTENSION ${INSTALL_V8JS_EXTENSION}
-
-RUN if [ ${INSTALL_V8JS_EXTENSION} = true ]; then \
-    # Install the php V8JS extension
-    add-apt-repository -y ppa:pinepain/libv8-5.4 \
-    && apt-get update \
-    && apt-get install -y php-dev php-pear libv8-5.4 \
-    && pecl install v8js \
-    && echo "extension=v8js.so" >> /etc/php/5.6/cli/php.ini \
-;fi
-
-#####################################
 # Non-root user : PHPUnit path
 #####################################
 

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -311,7 +311,7 @@ RUN if [ ${INSTALL_V8JS_EXTENSION} = true ]; then \
     # Install the php V8JS extension
     add-apt-repository -y ppa:pinepain/libv8-5.4 \
     && apt-get update \
-    && apt-get install -y php-dev php-pear libv8-5.4 \
+    && apt-get install -y php7.0-xml php7.0-dev php-pear libv8-5.4 \
     && pecl install v8js \
     && echo "extension=v8js.so" >> /etc/php/7.0/cli/php.ini \
 ;fi

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -307,7 +307,7 @@ RUN if [ ${INSTALL_V8JS_EXTENSION} = true ]; then \
     # Install the php V8JS extension
     add-apt-repository -y ppa:pinepain/libv8-5.4 \
     && apt-get update \
-    && apt-get install -y php-dev php-pear libv8-5.4 \
+    && apt-get install -y php-xml php-dev php-pear libv8-5.4 \
     && pecl install v8js \
     && echo "extension=v8js.so" >> /etc/php/7.1/cli/php.ini \
 ;fi


### PR DESCRIPTION
It seems that enabling V8JS installs php7.1 along when used in the php7.0 container. That's not what we want.

Also, it seems V8JS does not exist (anymore?) for php5.6:

> WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
pecl/v8js requires PHP (version >= 7.0), installed version is 5.6.30-10+deb.sury.org~xenial+2

Which brings us by this pull request: Changes to V8JS are the following.

- [x] Remove V8JS for PHP5.6
- [x] Change V8JS to not install PHP7.1 in PHP7.0 workspace
- [x] Add the XML extension for PHP when installing

Fixes #792.

Hopefully this'll also fix the Travis CI failing builds - assuming I did my work correctly. 
That's why I've added the `Priority: High` label here.