### PR TITLE
Update Redis Docker File

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -2,10 +2,13 @@ FROM redis:latest
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 
+## For security settings uncomment, make the dir, copy conf, and also start with the conf, to use it
+#RUN mkdir -p /usr/local/etc/redis
 #COPY redis.conf /usr/local/etc/redis/redis.conf
 
 VOLUME /data
 
 EXPOSE 6379
 
+#CMD ["redis-server", "/usr/local/etc/redis/redis.conf"]
 CMD ["redis-server"]


### PR DESCRIPTION
The dir for the conf seems to be missing from the base image, so the copy fails

Also if the server does not start with the conf as parameter it will not pick it up. Which leaves Redis wide open to attack by default:

Example try to telnet to your ip on the redis port for this container:   
telnet 192.168.1.11 6379  
echo "Hey no AUTH required!"