### PR TITLE
Fixed broken adoption for PUID and PGID for Non-Root User laradock.

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -46,8 +46,12 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 # Add a non-root user to prevent files being created with root permissions on host machine.
 ARG PUID=1000
 ARG PGID=1000
-RUN groupadd -g $PGID laradock && \
-    useradd -u $PUID -g laradock -m laradock
+
+ENV PUID ${PUID}
+ENV PGID ${PGID}
+
+RUN groupadd -g ${PGID} laradock && \
+    useradd -u ${PUID} -g laradock -m laradock
 
 
 #####################################

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -46,8 +46,12 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 # Add a non-root user to prevent files being created with root permissions on host machine.
 ARG PUID=1000
 ARG PGID=1000
-RUN groupadd -g $PGID laradock && \
-    useradd -u $PUID -g laradock -m laradock
+
+ENV PUID ${PUID}
+ENV PGID ${PGID}
+
+RUN groupadd -g ${PGID} laradock && \
+    useradd -u ${PUID} -g laradock -m laradock
 
 
 #####################################

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -46,8 +46,12 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 # Add a non-root user to prevent files being created with root permissions on host machine.
 ARG PUID=1000
 ARG PGID=1000
-RUN groupadd -g $PGID laradock && \
-    useradd -u $PUID -g laradock -m laradock
+
+ENV PUID ${PUID}
+ENV PGID ${PGID}
+
+RUN groupadd -g ${PGID} laradock && \
+    useradd -u ${PUID} -g laradock -m laradock
 
 
 #####################################


### PR DESCRIPTION
The values in the `.env` file were not used but always `1000:1000`.

This PR fixes the dockerfiles so the `.env` values are used.