### PR TITLE
COPY Caddyfile to docker image.

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -17,6 +17,8 @@ RUN curl --silent --show-error --fail --location \
     && mv /usr/bin/caddy /usr/bin/caddy \
     && chmod 0755 /usr/bin/caddy
 
+COPY Caddyfile /etc/Caddyfile
+
 EXPOSE 80 443 2015
 
 WORKDIR /var/www/public


### PR DESCRIPTION
The given Caddyfile would not be used if it's not copied to the image.