### PR TITLE
Fixing php-fpm show warning not install extension

### DIFF
--- a/php-fpm/laravel.ini
+++ b/php-fpm/laravel.ini
@@ -11,6 +11,3 @@ upload_max_filesize = 20M
 ; Sets max size of post data allowed.
 ; http://php.net/post-max-size
 post_max_size = 20M
-; Enables the MSSQL extensions
-extension=sqlsrv.so
-extension=pdo_sqlsrv.so


### PR DESCRIPTION
.env set PHP_FPM_INSTALL_MSSQL=false, but php -m get warning:
```
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/pdo_sqlsrv.so' - /usr/local/lib/php/extensions/no-debug-non-zts-20151012/pdo_sqlsrv.so: cannot open shared object file: No such file or directory in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/sqlsrv.so' - /usr/local/lib/php/extensions/no-debug-non-zts-20151012/sqlsrv.so: cannot open shared object file: No such file or directory in Unknown on line 0
```