### PR TITLE
Change DATA_SAVE_PATH default value avoid lost data

### DIFF
--- a/env-example
+++ b/env-example
@@ -10,7 +10,7 @@ APPLICATION=../
 ### Data Path:
 # For all storage systems.
 
-DATA_SAVE_PATH=/tmp
+DATA_SAVE_PATH=~/laradock/data
 
 ### PHP version
 # Applies to the Workspace and PHP-FPM containers (Does not apply to HHVM)

--- a/env-example
+++ b/env-example
@@ -10,7 +10,7 @@ APPLICATION=../
 ### Data Path:
 # For all storage systems.
 
-DATA_SAVE_PATH=~/laradock/data
+DATA_SAVE_PATH=~/.laradock/data
 
 ### PHP version
 # Applies to the Workspace and PHP-FPM containers (Does not apply to HHVM)


### PR DESCRIPTION
default env config DATA_SAVE_PATH from /tmp to ~/.laradock/data

avoid lost data and windows no have /tmp folder.

#966 