### PR TITLE
Kibana - Change to official repository

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,3 @@
-FROM kibana:latest
+FROM docker.elastic.co/kibana/kibana:5.4.1
 
 EXPOSE 5601


### PR DESCRIPTION
Elastic.co announced they will pull out their official images from the Docker Registry and user their own. There will be no updates starting 6/20/2017.

Pulling needs explicit version. Currently 5.4.1