### PR TITLE
ElasticSearch - Change to official repository

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,3 @@
-FROM elasticsearch:latest
-
-MAINTAINER Bo-Yi Wu <appleboy.tw@gmail.com>
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.4.1
 
 EXPOSE 9200 9300


### PR DESCRIPTION
Elastic.co announced they will pull out their official images from the Docker Registry and user their own. There will be no updates starting 6/20/2017.

Pulling needs explicit version. Currently 5.4.1