### PR TITLE
[Fix] Mailhog should be exposed to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -518,6 +518,7 @@ services:
         - "8025:8025"
       networks:
         - frontend
+        - backend
 
 ### Selenium Container ########################################
 


### PR DESCRIPTION
- fixes failing connection to host "mailhog" when sending mail via smtp
- mailhog needs to be available for the backend at Port 1025
- i.e. in a Laravel app .env should contain "MAIL_HOST=mailhog

### Original exception when sending mail through Laravel 5.4:
```
Swift_TransportException
Connection could not be established with host mailhog [php_network_getaddresses: getaddrinfo failed: Name or service not known #0]
```
with .env
```MAIL_DRIVER=smtp
MAIL_HOST=mailhog
MAIL_PORT=1025
MAIL_USERNAME=
MAIL_PASSWORD=
MAIL_ENCRYPTION=null
```

### Tested with:
```
➜  docker --version        
Docker version 17.03.1-ce, build c6d412e
➜  docker-compose --version             
docker-compose version 1.13.0, build 1719ceb
```
and plain Laravel 5.4

