### PR TITLE
add APACHE_SITES_PATH variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
         - applications
       volumes:
         - ${APACHE_HOST_LOG_PATH}:/var/log/apache2
-        - ./apache2/sites:/etc/apache2/sites-available
+        - ${APACHE_SITES_PATH}:/etc/apache2/sites-available
       ports:
         - "${APACHE_HOST_HTTP_PORT}:80"
         - "${APACHE_HOST_HTTPS_PORT}:443"

--- a/env-example
+++ b/env-example
@@ -85,6 +85,7 @@ APACHE_HOST_HTTP_PORT=80
 APACHE_HOST_HTTPS_PORT=443
 APACHE2_PHP_SOCKET=php-fpm:9000
 APACHE_HOST_LOG_PATH=./logs/apache2
+APACHE_SITES_PATH=./apache2/sites
 PHP_SOCKET=php-fpm:9000
 
 ### MYSQL ##############################################################################################################


### PR DESCRIPTION
Add `APACHE_SITES_PATH` to the main `docker-compose.yml` and `env-example`.

- Normalize the behaviour of the `apache2` container with the `nginx` container's `NGINX_SITES_PATH`

- [x] I've read the simple [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
