### PR TITLE
Parameterize docker-entrypoint-initdb.d for MySQL + MariaDB + Percona

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
         - TZ=${WORKSPACE_TIMEZONE}
       volumes:
         - ${DATA_SAVE_PATH}/mysql:/var/lib/mysql
-        - ./mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+        - ${MYSQL_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       ports:
         - "${MYSQL_PORT}:3306"
       networks:
@@ -218,7 +218,7 @@ services:
         - MYSQL_ROOT_PASSWORD=${PERCONA_ROOT_PASSWORD}
       volumes:
         - ${DATA_SAVE_PATH}/percona:/var/lib/mysql
-        - ./percona/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+        - ${PERCONA_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       ports:
         - "${PERCONA_PORT}:3306"
       networks:
@@ -246,7 +246,7 @@ services:
       build: ./mariadb
       volumes:
         - ${DATA_SAVE_PATH}/mariadb:/var/lib/mysql
-        - ./mariadb/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+        - ${MARIADB_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       ports:
         - "${MARIADB_PORT}:3306"
       environment:

--- a/env-example
+++ b/env-example
@@ -95,6 +95,7 @@ MYSQL_USER=default
 MYSQL_PASSWORD=secret
 MYSQL_PORT=3306
 MYSQL_ROOT_PASSWORD=root
+MYSQL_ENTRYPOINT_INITDB=./mysql/docker-entrypoint-initdb.d
 
 ### Percona ############################################################################################################
 
@@ -103,6 +104,7 @@ PERCONA_USER=homestead
 PERCONA_PASSWORD=secret
 PERCONA_PORT=3306
 PERCONA_ROOT_PASSWORD=root
+PERCONA_ENTRYPOINT_INITDB=./percona/docker-entrypoint-initdb.d
 
 ### MSSQL ##############################################################################################################
 
@@ -117,6 +119,7 @@ MARIADB_USER=default
 MARIADB_PASSWORD=secret
 MARIADB_PORT=3306
 MARIADB_ROOT_PASSWORD=root
+MARIADB_ENTRYPOINT_INITDB=./mariadb/docker-entrypoint-initdb.d
 
 ### POSTGRES ###########################################################################################################
 


### PR DESCRIPTION
Like the `*_SITES_PATH` variables, breaking out the `./*/docker-entrypoint-initdb.d` into `*_ENTRYPOINT_INITDB` variables will enable custom locations for the `createdb.sql` scripts.
Namely, when this project is used as git submodule, these customization can be defined without
modifying this project's source code.

##### Make sure you completed the basic 3 steps below:

- [x] I've read the simple [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
