### PR TITLE
fix php7.1-xdebug because of missing new line

### DIFF
--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -133,7 +133,8 @@ ARG INSTALL_XDEBUG=false
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
     apt-get update && \
-    apt-get install -y --force-yes php7.1-xdebug && \    sed -i 's/^;//g' /etc/php/7.1/cli/conf.d/20-xdebug.ini && \
+    apt-get install -y --force-yes php7.1-xdebug && \
+    sed -i 's/^;//g' /etc/php/7.1/cli/conf.d/20-xdebug.ini && \
     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/vendor/bin/phpunit'" >> ~/.bashrc \
 ;fi
 # ADD for REMOTE debugging


### PR DESCRIPTION
Workspace was not building with option INSTALL_XDEBUG set to true.
```
Step 30/115 : RUN if [ ${INSTALL_XDEBUG} = true ]; then     apt-get update &&     apt-get install -y --force-yes php7.1-xdebug && \    sed -i 's/^;//g' /etc/php/7.1/cli/conf.d/20-xdebug.ini &&     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/vendor/bin/phpunit'" >> ~/.bashrc ;fi
 ---> Running in f84ce15f7d4b
Get:1 http://ppa.launchpad.net/ondrej/php/ubuntu xenial InRelease [23.9 kB]
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [102 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-security InRelease [102 kB]
Fetched 228 kB in 4s (53.5 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  php-xdebug
0 upgraded, 1 newly installed, 0 to remove and 89 not upgraded.
Need to get 701 kB of archives.
After this operation, 3,727 kB of additional disk space will be used.
Get:1 http://ppa.launchpad.net/ondrej/php/ubuntu xenial/main amd64 php-xdebug amd64 2.5.5-3+ubuntu16.04.1+deb.sury.org+1 [701 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 701 kB in 26s (26.6 kB/s)
Selecting previously unselected package php-xdebug.
(Reading database ... 27232 files and directories currently installed.)
Preparing to unpack .../php-xdebug_2.5.5-3+ubuntu16.04.1+deb.sury.org+1_amd64.deb ...
Unpacking php-xdebug (2.5.5-3+ubuntu16.04.1+deb.sury.org+1) ...
Setting up php-xdebug (2.5.5-3+ubuntu16.04.1+deb.sury.org+1) ...
W: --force-yes is deprecated, use one of the options starting with --allow instead.
/bin/sh: 1:  : not found
ERROR: Service 'workspace' failed to build: The command '/bin/sh -c if [ ${INSTALL_XDEBUG} = true ]; then     apt-get update &&     apt-get install -y --force-yes php7.1-xdebug && \    sed -i 's/^;//g' /etc/php/7.1/cli/conf.d/20-x
```