### PR TITLE
fix php-worker build error

### DIFF
--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -37,5 +37,4 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 #--------------------------------------------------------------------------
 #
 
-RUN rm -r /var/lib/apt/lists/*
 WORKDIR /etc/supervisor/conf.d/


### PR DESCRIPTION
ERROR INFO:
```
Step 4/5 : RUN rm -r /var/lib/apt/lists/*
 ---> Running in 4a3aa49e0e6e
rm: can't remove '/var/lib/apt/lists/*': No such file or directory
ERROR: Service 'php-worker' failed to build: The command '/bin/sh -c rm -r /var/lib/apt/lists/*' returned a non-zero code: 1
```