### PR TITLE
[php-worker] dedicated dockerfile for php 7.0/7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
     php-worker:
       build:
         context: ./php-worker
+        dockerfile: "Dockerfile-${PHP_VERSION}"
       volumes_from:
         - applications
       depends_on:

--- a/php-worker/Dockerfile-70
+++ b/php-worker/Dockerfile-70
@@ -1,0 +1,59 @@
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+
+FROM php:7.0-alpine
+
+MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
+
+RUN apk --update add wget \
+  curl \
+  git \
+  build-base \
+  libmemcached-dev \
+  libmcrypt-dev \
+  libxml2-dev \
+  zlib-dev \
+  autoconf \
+  cyrus-sasl-dev \
+  libgsasl-dev \
+  supervisor
+
+RUN docker-php-ext-install mysqli mbstring pdo pdo_mysql mcrypt tokenizer xml
+RUN pecl channel-update pecl.php.net && pecl install memcached && docker-php-ext-enable memcached
+
+RUN rm /var/cache/apk/* \
+    && mkdir -p /var/www
+
+#
+#--------------------------------------------------------------------------
+# Optional Supervisord Configuration
+#--------------------------------------------------------------------------
+#
+# Modify the ./supervisor.conf file to match your App's requirements.
+# Make sure you rebuild your container with every change.
+#
+
+COPY supervisord.conf /etc/supervisord.conf
+
+ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c",  "/etc/supervisord.conf"]
+
+#
+#--------------------------------------------------------------------------
+# Optional Software's Installation
+#--------------------------------------------------------------------------
+#
+# If you need to modify this image, feel free to do it right here.
+#
+	# -- Your awesome modifications go here -- #
+
+
+#
+#--------------------------------------------------------------------------
+# Final Touch
+#--------------------------------------------------------------------------
+#
+
+WORKDIR /etc/supervisor/conf.d/

--- a/php-worker/Dockerfile-71
+++ b/php-worker/Dockerfile-71
@@ -3,13 +3,29 @@
 # Image Setup
 #--------------------------------------------------------------------------
 #
-# To take a look at the'php-worker' base Image, visit its DockerHub page
-#    https://hub.docker.com/r/nielsvdoorn/laravel-supervisor/
-#
 
-FROM nielsvdoorn/laravel-supervisor
+FROM php:7.1-alpine
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
+
+RUN apk --update add wget \
+  curl \
+  git \
+  build-base \
+  libmemcached-dev \
+  libmcrypt-dev \
+  libxml2-dev \
+  zlib-dev \
+  autoconf \
+  cyrus-sasl-dev \
+  libgsasl-dev \
+  supervisor
+
+RUN docker-php-ext-install mysqli mbstring pdo pdo_mysql mcrypt tokenizer xml
+RUN pecl channel-update pecl.php.net && pecl install memcached && docker-php-ext-enable memcached
+
+RUN rm /var/cache/apk/* \
+    && mkdir -p /var/www
 
 #
 #--------------------------------------------------------------------------
@@ -19,7 +35,10 @@ MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>
 # Modify the ./supervisor.conf file to match your App's requirements.
 # Make sure you rebuild your container with every change.
 #
+
 COPY supervisord.conf /etc/supervisord.conf
+
+ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c",  "/etc/supervisord.conf"]
 
 #
 #--------------------------------------------------------------------------
@@ -28,7 +47,7 @@ COPY supervisord.conf /etc/supervisord.conf
 #
 # If you need to modify this image, feel free to do it right here.
 #
-	# -- Your awesome modifications go here -- #
+    # -- Your awesome modifications go here -- #
 
 
 #


### PR DESCRIPTION
fixes #927: PHP-Worker container uses PHP-CLI 7.0.9 despite workspace using 7.1.4

It uses Niels van Doorns Dockerfile https://hub.docker.com/r/nielsvdoorn/laravel-supervisor/~/dockerfile/
but different **php:alpine** base images depending on the configured PHP version. 