### PR TITLE
Can't create/write to file '/var/lib/mysql/is_writable'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,7 @@ services:
         - ${MYSQL_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       ports:
         - "${MYSQL_PORT}:3306"
+      user: "1000:50"
       networks:
         - backend
 
@@ -475,7 +476,7 @@ services:
       networks:
         - frontend
         - backend
-      
+
 
 ### ElasticSearch Container #################################
 


### PR DESCRIPTION
I had issue that preventing me from starting mysql container, the error was like the following 

`Can't create/write to file '/var/lib/mysql/is_writable'`

I found that it's a problem related to the user permission, as the mysql user which is not able to access folders mounted from OSX/Windows.

Added `user: 1000:50` to fix that .  