### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,6 @@ services:
         - ${MYSQL_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       ports:
         - "${MYSQL_PORT}:3306"
-      user: "1000:50"
       networks:
         - backend
 


### PR DESCRIPTION
It looks like the 
     219: user: "1000:50" 
statement was added a while back to fix a file permissions issue, but on a new build it keeps mysql from starting, generating the following:

mysql_1                | Initializing database
mysql_1                | mysqld: Can't create/write to file '/var/lib/mysql/is_writable' (Errcode: 13 - Permission denied)
mysql_1                | 2017-09-14T23:55:30.989254Z 0 [Note] Basedir set to /usr/
mysql_1                | 2017-09-14T23:55:30.989559Z 0 [Warning] The syntax '--symbolic-links/-s' is deprecated and will be removed in a future release
mysql_1                | 2017-09-14T23:55:30.989602Z 0 [Warning] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
mysql_1                | 2017-09-14T23:55:30.990877Z 0 [ERROR] --initialize specified but the data directory exists and is not writable. Aborting.
mysql_1                | 2017-09-14T23:55:30.990886Z 0 [ERROR] Aborting

While researching the error I found a few other issues that mentioned removing this line as part of a workaround as well.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [NA] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X assuming I've done it well, my first time] I enjoyed my time contributing and making developer's life easier :)
