### PR TITLE
Fixed: Missing PgSQL PDO drivers

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -541,11 +541,18 @@ b) add a new service container by simply copy-paste this section below PHP-FPM c
 ```yaml
     php-worker:
       build:
-        context: ./php-fpm
-        dockerfile: Dockerfile-70 # or Dockerfile-56, choose your PHP-FPM container setting
+        context: ./php-worker
+        dockerfile: "Dockerfile-${PHP_VERSION}" #Dockerfile-71 or #Dockerfile-70 available
+        args:
+          - INSTALL_PGSQL=${PHP_WORKER_INSTALL_PGSQL} #Optionally install PGSQL PHP drivers
       volumes_from:
         - applications
-      command: php artisan queue:work
+      depends_on:
+        - workspace
+      extra_hosts:
+        - "dockerhost:${DOCKER_HOST_IP}"
+      networks:
+        - backend
 ```
 2 - Start everything up
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,8 @@ services:
       build:
         context: ./php-worker
         dockerfile: "Dockerfile-${PHP_VERSION}"
+        args:
+          - INSTALL_PGSQL=${PHP_WORKER_INSTALL_PGSQL}
       volumes_from:
         - applications
       depends_on:

--- a/env-example
+++ b/env-example
@@ -88,6 +88,10 @@ PHP_FPM_INSTALL_IMAGE_OPTIMIZERS=false
 PHP_FPM_INSTALL_IMAGEMAGICK=false
 PHP_FPM_INSTALL_PG_CLIENT=false
 
+### PHP_WORKER #########################################################################################################
+
+PHP_WORKER_INSTALL_PGSQL=false
+
 ### NGINX ##############################################################################################################
 
 NGINX_HOST_HTTP_PORT=80

--- a/php-worker/Dockerfile-70
+++ b/php-worker/Dockerfile-70
@@ -24,6 +24,13 @@ RUN apk --update add wget \
 RUN docker-php-ext-install mysqli mbstring pdo pdo_mysql mcrypt tokenizer xml
 RUN pecl channel-update pecl.php.net && pecl install memcached && docker-php-ext-enable memcached
 
+# Install PostgreSQL drivers:
+ARG INSTALL_PGSQL=false
+RUN if [ ${INSTALL_PGSQL} = true ]; then \
+    apk --update add postgresql-dev \
+        && docker-php-ext-install pdo_pgsql \
+;fi
+
 RUN rm /var/cache/apk/* \
     && mkdir -p /var/www
 

--- a/php-worker/Dockerfile-71
+++ b/php-worker/Dockerfile-71
@@ -24,6 +24,13 @@ RUN apk --update add wget \
 RUN docker-php-ext-install mysqli mbstring pdo pdo_mysql mcrypt tokenizer xml
 RUN pecl channel-update pecl.php.net && pecl install memcached && docker-php-ext-enable memcached
 
+# Install PostgreSQL drivers:
+ARG INSTALL_PGSQL=false
+RUN if [ ${INSTALL_PGSQL} = true ]; then \
+    apk --update add postgresql-dev \
+        && docker-php-ext-install pdo_pgsql \
+;fi
+
 RUN rm /var/cache/apk/* \
     && mkdir -p /var/www
 


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [y] I've read the [Contribution Guide](http://laradock.io/contributing).
- [y] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [y] I enjoyed my time contributing and making developer's life easier :)

This is an attempt to resolve:

https://github.com/laradock/laradock/issues/1218
https://github.com/laradock/laradock/issues/1217

As an overview:
- I added a new environment variable: PHP_WORKER_INSTALL_PGSQL
- Added missing driver install to PHP-Worker dockerfiles
- Updated the (somewhat outdated) documentation on PHP workers.

Happy to make changes as necessary,  but followed the structure of the repo as best I could.
