### PR TITLE
solving python issue when using INSTALL_NODE=true and VueJS with Laravel.

### DIFF
--- a/env-example
+++ b/env-example
@@ -322,4 +322,3 @@ PHP_IDE_CONFIG=serverName=laradock
 # Fix for windows users to make sure the application path works.
 
 COMPOSE_CONVERT_WINDOWS_PATHS=1
-

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -52,7 +52,8 @@ ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
     useradd -u ${PUID} -g laradock -m laradock && \
-    apt-get update -yqq
+    apt-get update -yqq \
+    apt-get install -y python2.7
 
 #####################################
 # SOAP:
@@ -682,7 +683,8 @@ RUN if [ ${INSTALL_DUSK_DEPS} = true ]; then \
 # Clean up
 USER root
 RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    npm config set python /usr/bin/python2.7
 
 # Set default work directory
 WORKDIR /var/www


### PR DESCRIPTION
I got a problem using Laradock and VueJS dependencies managed by NPM. I used INSTALL_NODE = true but when trying to npm install, not working with a python based error. 

I managed to fix it installing python and let npm knows about its location. Easy fix but could be very useful for everyone who's trying to use VueJS or, more generally, npm with Laravel. 

Thanks

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
