### PR TITLE
Fix Dockerfile

### DIFF
--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -52,7 +52,7 @@ ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
     useradd -u ${PUID} -g laradock -m laradock && \
-    apt-get update -yqq \
+    apt-get update -yqq && \
     apt-get install -y python2.7
 
 #####################################


### PR DESCRIPTION
Building the workspace docker image with Dockerfile-71 failed because
of missing "&&"

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
