### PR TITLE
Fix logo covering links in mobile drawer menu (Closes #1252)

### DIFF
--- a/DOCUMENTATION/themes/hugo-material-docs/layouts/partials/drawer.html
+++ b/DOCUMENTATION/themes/hugo-material-docs/layouts/partials/drawer.html
@@ -5,6 +5,7 @@
         <div class="logo">
           <img src="{{ $.Site.BaseURL }}{{ . }}">
         </div>
+        Laradock
       {{ end }}
       <!--<div class="name">-->
         <!--<strong>{{ .Site.Title }} {{ with .Site.Params.version }}<span class="version">{{ . }}</span>{{ end }}</strong>-->

--- a/DOCUMENTATION/themes/hugo-material-docs/static/stylesheets/highlight/highlight.css
+++ b/DOCUMENTATION/themes/hugo-material-docs/static/stylesheets/highlight/highlight.css
@@ -108,9 +108,17 @@ font-weight:700;
     OVERRIDING THE DEFAULT STYLES - By Mahmoud Zalt (mahmoud@zalt.me) for Laradock.io
 */
 
-.project .logo img{
-    width: 140px;
-    height: 140px;
+
+.project .logo img {
+    max-width: 100%;
+    height: auto;
     background: transparent;
     border-radius: 0%;
+}
+
+.project .banner {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: bold;
 }


### PR DESCRIPTION
Here's a before and after of the changes:

## Mobile

| **BEFORE**        | **AFTER**           |
| ------------- |:-------------:|
| ![drawer-before-mobile](https://user-images.githubusercontent.com/12969835/32789271-09e8f7c4-c921-11e7-8445-79bd95c14f2b.png) | ![drawer-after](https://user-images.githubusercontent.com/12969835/32789287-101d953c-c921-11e7-9d77-5586e198ac03.png) |

## Desktop

| **BEFORE**        | **AFTER**           |
| ------------- |:-------------:|
| ![drawer-before-desktop](https://user-images.githubusercontent.com/12969835/32789210-e28988d8-c920-11e7-8aae-517b70e9d672.png) | ![drawer-after-desktop](https://user-images.githubusercontent.com/12969835/32789212-e67cf48e-c920-11e7-815a-075036a8507c.png)|
