### PR TITLE
Remove python installation from Dockerfile-71

### DIFF
--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -54,9 +54,7 @@ ENV PUID ${PUID}
 ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
-    useradd -u ${PUID} -g laradock -m laradock && \
-    apt-get update -yqq && \
-    apt-get install -y python2.7
+    useradd -u ${PUID} -g laradock -m laradock
 
 #####################################
 # SOAP:
@@ -686,8 +684,7 @@ RUN if [ ${INSTALL_DUSK_DEPS} = true ]; then \
 # Clean up
 USER root
 RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    npm config set python /usr/bin/python2.7
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set default work directory
 WORKDIR /var/www


### PR DESCRIPTION
Python can be installed by using the WORKSPACE_INSTALL_PYTHON
variable in the .env file. Fixes #1238

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
