### PR TITLE
Specifying included docker-compose files in the .env is more flexible

### DIFF
--- a/env-example
+++ b/env-example
@@ -7,6 +7,9 @@
 
 COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 
+# Replace the above with the following line if you wish to use docker-sync.
+# COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:docker-compose.sync.yml
+
 ### Application Path ###################################################################################################
 # Point to your code, will be available at `/var/www`.
 

--- a/sync.sh
+++ b/sync.sh
@@ -59,7 +59,7 @@ if [ "$1" == "up" ] ; then
 
     print_style "Initializing Docker Compose\n" "info"
     shift # removing first argument
-    docker-compose -f docker-compose.yml -f docker-compose.sync.yml up -d ${@}
+    docker-compose up -d ${@}
 
 elif [ "$1" == "down" ]; then
     print_style "Stopping Docker Compose\n" "info"


### PR DESCRIPTION
Specifying included docker-compose files in the .env is more flexible than hardcoding them in the shell script.