### PR TITLE
Clarified how to split multiple docker-compose files on Windows

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -162,6 +162,7 @@ cp env-example .env
 
 You can edit the `.env` file to chose which software's you want to be installed in your environment. You can always refer to the `docker-compose.yml` file to see how those variables are been used.
 
+Depending on the host's operating system you may need to change the value given to `COMPOSE_FILE`. When you are running Laradock on Mac OS the correct file separator to use is `:`. When running Laradock from a Windows environment multiple files must be separated with `;`.
 
 2 - Build the enviroment and run it using `docker-compose`
 

--- a/env-example
+++ b/env-example
@@ -25,6 +25,7 @@ DATA_SAVE_PATH=~/.laradock/data
 ### Docker compose files ###############################################################################################
 # Select which docker-compose files to include.
 # If using docker-sync. Set the value to: docker-compose.yml:docker-compose.dev.yml:docker-compose.sync.yml
+# Change the separator from : to ; on Windows
 
 COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 


### PR DESCRIPTION
As seen in #1268, is it unclear in the latest version that COMPOSE_FILE must separate files with `;` on Windows when setting up Laradock.

This PR adds both a new comment in `.env-example` and on the Getting Started page.

Fell free to reject this PR if you'd rather automate the separator toggle instead of adding the details to the docs. Seems like a quick win at the moment though.
