### PR TITLE
Don't use docker-compose down to stop containers

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -63,7 +63,7 @@ if [ "$1" == "up" ] ; then
 
 elif [ "$1" == "down" ]; then
     print_style "Stopping Docker Compose\n" "info"
-    docker-compose down
+    docker-compose stop
 
     print_style "Stopping Docker Sync\n" "info"
     docker-sync stop


### PR DESCRIPTION
This delete containers and volume too. 
Use docker-compose stop who only stop containers

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)

if i read the sync.sh down command info : "Stops containers and docker-sync" this don't say we have to delete containers and volumes.

Currently this use command docker-compose down who delete containers/volumes etc. doc (https://docs.docker.com/compose/reference/down/)

Replace it by docker-compose stop to only stop containers. 

