### PR TITLE
Compatibility for COMPOSE_FILE

### DIFF
--- a/env-example
+++ b/env-example
@@ -26,6 +26,7 @@ DATA_SAVE_PATH=~/.laradock/data
 # Select which docker-compose files to include.
 # If using docker-sync. Set the value to: docker-compose.yml:docker-compose.dev.yml:docker-compose.sync.yml
 
+COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 
 ### Docker Host IP #####################################################################################################


### PR DESCRIPTION
COMPOSE_PATH_SEPARATOR
If set, the value of the COMPOSE_FILE environment variable will be separated using this character as path separator.

Docs:
https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
