### PR TITLE
fix bug on nginx container

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,8 +9,7 @@ ADD nginx.conf /etc/nginx/
 ARG CHANGE_SOURCE=false
 RUN if [ ${CHANGE_SOURCE} = true ]; then \
     # Change application source from dl-cdn.alpinelinux.org to aliyun source
-    RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories
-;fi
+    RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories;fi
 
 RUN apk update \
     && apk upgrade \


### PR DESCRIPTION
There is an error in the DockerFile of the Nginx container ( only for Ubuntu users, it works fine in Mac OS ). ERROR: Dockerfile parse error line 13: unknown instruction: ;FI
It should be: 
`
ARG CHANGE_SOURCE=false
RUN if [ ${CHANGE_SOURCE} = true ]; then \
    # Change application source from dl-cdn.alpinelinux.org to aliyun source
    RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories;fi`

