### PR TITLE
Add LDAP support to PHP 5.6 workspace

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -73,6 +73,19 @@ RUN if [ ${INSTALL_SOAP} = true ]; then \
 ;fi
 
 #####################################
+# LDAP:
+#####################################
+
+ARG INSTALL_LDAP=false
+ENV INSTALL_LDAP ${INSTALL_LDAP}
+
+RUN if [ ${INSTALL_LDAP} = true ]; then \
+    apt-get update -yqq && \
+    apt-get install -y libldap2-dev && \
+    apt-get install -y php5.6-ldap \
+;fi
+
+#####################################
 # IMAP:
 #####################################
 USER root


### PR DESCRIPTION
Issue #1296:
PHP 7.0 and 7.1 workspaces support adding the PHP LDAP module. The
PHP 5.6 workspace file seems to have missed this for some reason.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] N/A I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
