### PR TITLE
Give minio access to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,8 @@ services:
     minio:
       build: ./minio
       volumes:
-        - minio:/export
+        - ${DATA_SAVE_PATH}/minio/data:/export
+        - ${DATA_SAVE_PATH}/minio/config:/root/.minio
       ports:
         - "${MINIO_PORT}:9000"
       environment:
@@ -206,6 +207,7 @@ services:
         - MINIO_SECRET_KEY=secretkey
       networks:
         - frontend
+        - backend
 
 ### MySQL Container #########################################
 


### PR DESCRIPTION
This pull request will make the following changes to minio:

- Give minio access to backend
- Add volume to persist minio configuration in the standard DATA_SAVE_PATH
- Modify minio data volume to use the standard DATA_SAVE_PATH

It fixes issue #1085 

Mickaël
