### PR TITLE
Update index.md

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -125,6 +125,7 @@ You can rename the config files, project folders and domains as you like, just m
 127.0.0.1  project-2.dev
 ...
 ```
+If you use Chrome 63 or above for development, don't use `.dev`. [Why?](https://laravel-news.com/chrome-63-now-forces-dev-domains-https). Insteand use `.localhost`, `.invalid`, `.test`, or `.example`.
 
 > **Now jump to the [Usage](#Usage) section.**
 

--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -125,7 +125,7 @@ You can rename the config files, project folders and domains as you like, just m
 127.0.0.1  project-2.dev
 ...
 ```
-If you use Chrome 63 or above for development, don't use `.dev`. [Why?](https://laravel-news.com/chrome-63-now-forces-dev-domains-https). Insteand use `.localhost`, `.invalid`, `.test`, or `.example`.
+If you use Chrome 63 or above for development, don't use `.dev`. [Why?](https://laravel-news.com/chrome-63-now-forces-dev-domains-https). Instead use `.localhost`, `.invalid`, `.test`, or `.example`.
 
 > **Now jump to the [Usage](#Usage) section.**
 


### PR DESCRIPTION
Google Chrome is releasing v63 which now forces all .dev domains to use HTTPS. Me and my co-workers had problems with this, so I do not want this to happen to others.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
