### PR TITLE
Ssh for laradock user

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -209,6 +209,8 @@ RUN if [ ${INSTALL_WORKSPACE_SSH} = true ]; then \
         && rm -f /tmp/id_rsa* \
         && chmod 644 /root/.ssh/authorized_keys /root/.ssh/id_rsa.pub \
     && chmod 400 /root/.ssh/id_rsa \
+    && cp -rf /root/.ssh /home/laradock \
+    && chown -R laradock:laradock /home/laradock/.ssh \
 ;fi
 
 #####################################

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -206,6 +206,8 @@ RUN if [ ${INSTALL_WORKSPACE_SSH} = true ]; then \
         && rm -f /tmp/id_rsa* \
         && chmod 644 /root/.ssh/authorized_keys /root/.ssh/id_rsa.pub \
     && chmod 400 /root/.ssh/id_rsa \
+    && cp -rf /root/.ssh /home/laradock \
+    && chown -R laradock:laradock /home/laradock/.ssh \
 ;fi
 
 #####################################

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -202,6 +202,8 @@ RUN if [ ${INSTALL_WORKSPACE_SSH} = true ]; then \
         && rm -f /tmp/id_rsa* \
         && chmod 644 /root/.ssh/authorized_keys /root/.ssh/id_rsa.pub \
     && chmod 400 /root/.ssh/id_rsa \
+    && cp -rf /root/.ssh /home/laradock \
+    && chown -R laradock:laradock /home/laradock/.ssh \
 ;fi
 
 #####################################


### PR DESCRIPTION
Now ssh keys can be used only from `root` user by default.
Sometimes you will need to do something like install composer dependencies from your own private repositories via ssh keys and etc. 

So It will be good to allow it for laradock user (not root only) out of the box.