### PR TITLE
add memory to process up elastiseach

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -503,12 +503,12 @@ services:
       environment:
         - cluster.name=laradock-cluster
         - bootstrap.memory_lock=true
-        - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       ulimits:
         memlock:
           soft: -1
           hard: -1
-      mem_limit: 512m
+      mem_limit: 1024m
       ports:
         - "${ELASTICSEARCH_HOST_HTTP_PORT}:9200"
         - "${ELASTICSEARCH_HOST_TRANSPORT_PORT}:9300"


### PR DESCRIPTION
also on host pc run the command sysctl -w vm.max_map_count=262144

https://www.elastic.co/guide/en/elasticsearch/reference/5.4/vm-max-map-count.html

reference to error #1328 


