### PR TITLE
Update supervisord.conf to enable supervisorctl

### DIFF
--- a/php-worker/supervisord.conf
+++ b/php-worker/supervisord.conf
@@ -1,5 +1,11 @@
 [supervisord]
 nodaemon=true
+[supervisorctl]
+[inet_http_server]
+port = 127.0.0.1:9001
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:laravel-worker]
 process_name=%(program_name)s_%(process_num)02d
 command=php /var/www/artisan queue:work --sleep=3 --tries=3 --daemon


### PR DESCRIPTION
Enabling supervisorctl allow us to start/stop one service without having to stop the entire container for example. Usefull when we have many php process running.

From inside container : 
`supervisorctl stop laravel-worker
`
From docker-compose : 
`docker-compose exec php-worker supervisorctl stop laravel-worker`