### PR TITLE
specify 7.1 version of php

### DIFF
--- a/php-fpm/Dockerfile-56
+++ b/php-fpm/Dockerfile-56
@@ -121,7 +121,7 @@ RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
 ARG INSTALL_SWOOLE=false
 RUN if [ ${INSTALL_SWOOLE} = true ]; then \
     # Install Php Swoole Extension
-    pecl install swoole \
+    pecl install swoole-2.0.11 \
     &&  docker-php-ext-enable swoole \
 ;fi
 

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -46,7 +46,7 @@ ARG INSTALL_SOAP=false
 RUN if [ ${INSTALL_SOAP} = true ]; then \
     # Install the soap extension
     apt-get update -yqq && \
-    apt-get -y install libxml2-dev php7.1-soap && \
+    apt-get -y install libxml2-dev php-soap && \
     docker-php-ext-install soap \
 ;fi
 

--- a/php-fpm/Dockerfile-71
+++ b/php-fpm/Dockerfile-71
@@ -46,7 +46,7 @@ ARG INSTALL_SOAP=false
 RUN if [ ${INSTALL_SOAP} = true ]; then \
     # Install the soap extension
     apt-get update -yqq && \
-    apt-get -y install libxml2-dev php-soap && \
+    apt-get -y install libxml2-dev php7.1-soap && \
     docker-php-ext-install soap \
 ;fi
 

--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -263,7 +263,7 @@ RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
 ARG INSTALL_SWOOLE=false
 RUN if [ ${INSTALL_SWOOLE} = true ]; then \
     # Install Php Swoole Extension
-    pecl -q install swoole && \
+    pecl -q install swoole-2.0.11 && \
     echo "extension=swoole.so" >> /etc/php/5.6/mods-available/swoole.ini && \
     ln -s /etc/php/5.6/mods-available/swoole.ini /etc/php/5.6/cli/conf.d/20-swoole.ini \
 ;fi

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -409,7 +409,7 @@ RUN if [ ${INSTALL_V8JS} = true ]; then \
     # Install the php V8JS extension
     add-apt-repository -y ppa:pinepain/libv8-5.4 \
     && apt-get update -yqq \
-    && apt-get install -y php-xml php-dev php-pear libv8-5.4 \
+    && apt-get install -y php7.1-xml php7.1-dev php-pear libv8-5.4 \
     && pecl install v8js \
     && echo "extension=v8js.so" >> /etc/php/7.1/cli/php.ini \
 ;fi

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -68,7 +68,7 @@ RUN if [ ${INSTALL_SOAP} = true ]; then \
   # Install the PHP SOAP extension
   add-apt-repository -y ppa:ondrej/php && \
   apt-get update -yqq && \
-  apt-get -y install libxml2-dev php7.1-soap \
+  apt-get -y install libxml2-dev php-soap \
 ;fi
 
 #####################################


### PR DESCRIPTION
Using `php7.1-xml php7.1-dev` instead of `php-xml php-dev` because right now, installing `php-xml` and  `php-dev` will install the version 7.2 instead of 7.1

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
