### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -458,9 +458,9 @@ services:
       build: ./phpmyadmin
       environment:
         - PMA_ARBITRARY=1
-        - MYSQL_USER=${PMA_USER}
-        - MYSQL_PASSWORD=${PMA_PASSWORD}
-        - MYSQL_ROOT_PASSWORD=${PMA_ROOT_PASSWORD}
+        - PMA_USER=${PMA_USER}
+        - PMA_PASSWORD=${PMA_PASSWORD}
+        - PMA_ROOT_PASSWORD=${PMA_ROOT_PASSWORD}
       ports:
         - "${PMA_PORT}:80"
       depends_on:


### PR DESCRIPTION
According to the [phpmyadmin/phpmyadmin](https://hub.docker.com/r/phpmyadmin/phpmyadmin/) config file
https://github.com/phpmyadmin/docker/blob/master/etc/phpmyadmin/config.inc.php#L14
they are using prefix `PMA_` , not `MYSQL`