### PR TITLE
Make possible to login via ssh using the laradock user.

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -1092,7 +1092,18 @@ To change the default forwarded port for ssh:
     ...
 ```
 
+Then login using:
 
+```bash
+ssh -o PasswordAuthentication=no    \
+    -o StrictHostKeyChecking=no     \
+    -o UserKnownHostsFile=/dev/null \
+    -p 2222                         \
+    -i workspace/insecure_id_rsa    \
+    laradock@localhost
+```
+
+To login as root, replace laradock@locahost with root@localhost.
 
 <br>
 <a name="Change-the-MySQL-Version"></a>

--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -55,6 +55,7 @@ ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
     useradd -u ${PUID} -g laradock -m laradock && \
+    usermod -p "*" laradock && \
     apt-get update -yqq
 
 #####################################

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -55,6 +55,7 @@ ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
     useradd -u ${PUID} -g laradock -m laradock && \
+    usermod -p "*" laradock && \
     apt-get update -yqq
 
 #####################################

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -54,7 +54,8 @@ ENV PUID ${PUID}
 ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
-    useradd -u ${PUID} -g laradock -m laradock
+    useradd -u ${PUID} -g laradock -m laradock && \
+    usermod -p "*" laradock
 
 #####################################
 # SOAP:

--- a/workspace/Dockerfile-72
+++ b/workspace/Dockerfile-72
@@ -54,7 +54,9 @@ ENV PUID ${PUID}
 ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
-    useradd -u ${PUID} -g laradock -m laradock
+    useradd -u ${PUID} -g laradock -m laradock && \
+    usermod -p "*" laradock
+
 
 #####################################
 # SOAP:


### PR DESCRIPTION
Fixes #1372 

Currently it is not possible to login using laradock user (ssh laradock@localhost gives you access denied). The problem as described in #1372 is that the laradock user is locked. http://arlimus.github.io/articles/usepam/ says that is possible to log in using ssh changing the `laradock:!` to  `laradock:*` in `/etc/shadow`


##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
