### PR TITLE
Reference beanstalkd-console host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,7 +429,7 @@ services:
     beanstalkd-console:
       build: ./beanstalkd-console
       ports:
-        - "2080:2080"
+        - "${BEANSTALKD_CONSOLE_HOST_PORT}:2080"
       depends_on:
         - beanstalkd
       networks:


### PR DESCRIPTION
This pull request references the of `BEANSTALKD_CONSOLE_HOST_PORT` from the `.env` file in the `docker-compose.yml`. Prior to this PR, the environment variable was defined in the `.env` file but was not used.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
