### PR TITLE
PPA 'pinepain/libv8-5.4' has been deprecated, use 'pinepain/libv8-archived' instead

### DIFF
--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -422,7 +422,7 @@ ENV INSTALL_V8JS ${INSTALL_V8JS}
 
 RUN if [ ${INSTALL_V8JS} = true ]; then \
     # Install the php V8JS extension
-    add-apt-repository -y ppa:pinepain/libv8-5.4 \
+    add-apt-repository -y ppa:pinepain/libv8-archived \
     && apt-get update -yqq \
     && apt-get install -y php7.0-xml php7.0-dev php-pear libv8-5.4 \
     && pecl install v8js \

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -422,7 +422,7 @@ ENV INSTALL_V8JS ${INSTALL_V8JS}
 
 RUN if [ ${INSTALL_V8JS} = true ]; then \
     # Install the php V8JS extension
-    add-apt-repository -y ppa:pinepain/libv8-5.4 \
+    add-apt-repository -y ppa:pinepain/libv8-archived \
     && apt-get update -yqq \
     && apt-get install -y php7.1-xml php7.1-dev php-pear libv8-5.4 \
     && pecl install v8js \

--- a/workspace/Dockerfile-72
+++ b/workspace/Dockerfile-72
@@ -407,7 +407,7 @@ ENV INSTALL_V8JS ${INSTALL_V8JS}
 
 RUN if [ ${INSTALL_V8JS} = true ]; then \
     # Install the php V8JS extension
-    add-apt-repository -y ppa:pinepain/libv8-5.4 \
+    add-apt-repository -y ppa:pinepain/libv8-archived \
     && apt-get update -yqq \
     && apt-get install -y php-xml php-dev php-pear libv8-5.4 \
     && pecl install v8js \


### PR DESCRIPTION
The PPA of `pinepain/libv8-5.4` has been deprecated, use `pinepain/libv8-archived` instead.
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
