### PR TITLE
Run apt-get update before installing imagemagick in workspace

### DIFF
--- a/workspace/Dockerfile-56
+++ b/workspace/Dockerfile-56
@@ -603,7 +603,8 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 ENV INSTALL_IMAGEMAGICK ${INSTALL_IMAGEMAGICK}
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
-    apt-get install -y --force-yes imagemagick php-imagick \
+    apt-get update -yqq \
+    && apt-get install -y --force-yes imagemagick php-imagick \
 ;fi
 
 #####################################

--- a/workspace/Dockerfile-70
+++ b/workspace/Dockerfile-70
@@ -680,7 +680,8 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 ENV INSTALL_IMAGEMAGICK ${INSTALL_IMAGEMAGICK}
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
-    apt-get install -y --force-yes imagemagick php-imagick \
+    apt-get update -yqq \
+    && apt-get install -y --force-yes imagemagick php-imagick \
 ;fi
 
 #####################################

--- a/workspace/Dockerfile-71
+++ b/workspace/Dockerfile-71
@@ -693,7 +693,8 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 ENV INSTALL_IMAGEMAGICK ${INSTALL_IMAGEMAGICK}
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
-    apt-get install -y --force-yes imagemagick php-imagick \
+    apt-get update -yqq \
+    && apt-get install -y --force-yes imagemagick php-imagick \
 ;fi
 
 #####################################

--- a/workspace/Dockerfile-72
+++ b/workspace/Dockerfile-72
@@ -666,7 +666,8 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 ENV INSTALL_IMAGEMAGICK ${INSTALL_IMAGEMAGICK}
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
-    apt-get install -y --force-yes imagemagick php-imagick \
+    apt-get update -yqq \
+    && apt-get install -y --force-yes imagemagick php-imagick \
 ;fi
 
 #####################################


### PR DESCRIPTION
Signed-off-by: Suhaib Khan <suheb.work@gmail.com>

Currently, the build break as it doesn't find the required package.
This makes sure the apt repository is up-to-date before attempting to install `imagemagick`
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)