### PR TITLE
Update mysql version to latest

### DIFF
--- a/env-example
+++ b/env-example
@@ -150,7 +150,7 @@ APACHE_PHP_UPSTREAM_TIMEOUT=60
 
 ### MYSQL ##############################################################################################################
 
-MYSQL_VERSION=8.0
+MYSQL_VERSION=latest
 MYSQL_DATABASE=default
 MYSQL_USER=default
 MYSQL_PASSWORD=secret

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-ARG MYSQL_VERSION=8.0
+ARG MYSQL_VERSION=latest
 FROM mysql:${MYSQL_VERSION}
 
 MAINTAINER Mahmoud Zalt <mahmoud@zalt.me>


### PR DESCRIPTION
Signed-off-by: Suhaib Khan <suheb.work@gmail.com>
This install the latest version of mysql be default. Fixes issues related to caching_sha2_password (#1390 #1392 #1407).

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
