### PR TITLE
Fix nginx default  root path

### DIFF
--- a/nginx/sites/default.conf
+++ b/nginx/sites/default.conf
@@ -4,7 +4,7 @@ server {
     listen [::]:80 default_server ipv6only=on;
 
     server_name localhost;
-    root /var/www/public;
+    root /usr/share/nginx/html;
     index index.php index.html index.htm;
 
     location / {


### PR DESCRIPTION
The default root path of nginx is "/usr/share/nginx/html", but current config file is "/var/www/public".

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
