### PR TITLE
Enable calling node commands (npm, bower, etc) from the host with 'do…

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -373,6 +373,20 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
 # Add PATH for node
 ENV PATH $PATH:$NVM_DIR/versions/node/v${NODE_VERSION}/bin
 
+# Make it so the node modules can be executed with 'docker-compose exec'
+# We'll create symbolic links into '/usr/local/bin'.
+RUN if [ ${INSTALL_NODE} = true ]; then \
+    find $NVM_DIR -type f -name node -exec ln -s {} /usr/local/bin/node \; && \
+    NODE_MODS_DIR="$NVM_DIR/versions/node/$(node -v)/lib/node_modules" && \
+    ln -s $NODE_MODS_DIR/bower/bin/bower /usr/local/bin/bower && \
+    ln -s $NODE_MODS_DIR/gulp/bin/gulp.js /usr/local/bin/gulp && \
+    ln -s $NODE_MODS_DIR/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s $NODE_MODS_DIR/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    ln -s $NODE_MODS_DIR/vue-cli/bin/vue /usr/local/bin/vue && \
+    ln -s $NODE_MODS_DIR/vue-cli/bin/vue-init /usr/local/bin/vue-init && \
+    ln -s $NODE_MODS_DIR/vue-cli/bin/vue-list /usr/local/bin/vue-list \
+;fi
+
 RUN if [ ${NPM_REGISTRY} ]; then \
     . ~/.bashrc && npm config set registry ${NPM_REGISTRY} \
 ;fi


### PR DESCRIPTION
This fixes an issue preventing you from executing node commands (npm, bower, etc) from the host by using 'docker-compose exec workspace ...', even with `WORKSPACE_INSTALL_NODE` set to true.
If you try, you get the following error:

```
OCI runtime exec failed: exec failed: container_linux.go:296: starting container process caused "exec: \"npm\": executable file not found in $PATH": unknown
```

For it to work, you have to `docker-compose exec workspace bash` into the container beforehand.

After some probing around, I realized this issue came from the fact that the `docker-compose exec` command somehow uses the host's PATH environment variable instead of the container's.
I modified the workspace/Dockerfile so that symbolic links pointing to the node modules executable files are created in '/usr/local/bin'.

> <!--- Thank you for contributing to Laradock -->
> 
> ##### I completed the 3 steps below:
> 
> - [x] I've read the [Contribution Guide](http://laradock.io/contributing).
> - [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
> - [x] I enjoyed my time contributing and making developer's life easier :)

I'd love to update the codumentation, however I'm a bit confused as to what I should edit.
