### PR TITLE
run php-fpm under workspace user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
           - INSTALL_SWOOLE=${PHP_FPM_INSTALL_SWOOLE}
           - INSTALL_IMAGE_OPTIMIZERS=${PHP_FPM_INSTALL_IMAGE_OPTIMIZERS}
           - INSTALL_IMAGEMAGICK=${PHP_FPM_INSTALL_IMAGEMAGICK}
+          - PUID=${WORKSPACE_PUID}
       volumes:
         - ./php-fpm/php${PHP_VERSION}.ini:/usr/local/etc/php/php.ini
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -412,7 +412,13 @@ RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     rm /var/log/lastlog /var/log/faillog
 
+ARG PUID=1000
+ENV PUID ${PUID}
+
 RUN usermod -u 1000 www-data
+# hack because usermod -u ${PUID} will be freeze when you have a large uid (domain user)
+RUN sed -i -e "s/:1000:/:${PUID}:/g" /etc/passwd
+
 
 WORKDIR /var/www
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -32,7 +32,7 @@ ARG PGID=1000
 ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
-    useradd -u ${PUID} -g laradock -m laradock -G docker_env && \
+    useradd -l -u ${PUID} -g laradock -m laradock -G docker_env && \
     usermod -p "*" laradock
 
 #


### PR DESCRIPTION
Run php-fpm under the workspace user. This solve all permissions problems. All files like cache files will be created with the same user

I have also add -l flag to useradd. When you use laradock with a domain user you have a large uid and your machine will be frezze by useradd without -l flag. usermod has no -l flag so I use a sed hack in php-fpm Dockerfile to avoid the frezze problem.
 
See: https://github.com/moby/moby/issues/5419 or
https://forums.docker.com/t/run-adduser-seems-to-hang-with-large-uid/27371

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
