### PR TITLE
Fix env variable name

### DIFF
--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -6,7 +6,7 @@ syncs:
   applications-docker-sync: # name of the intermediary sync volume
     compose-dev-file-path: 'docker-compose.sync.yml' # docker-compose override file
 
-    src: '${APPLICATION}' # host source directory
+    src: '${APP_CODE_PATH_HOST}' # host source directory
     sync_userid: 1000 # giving permissions to www-data user (as defined in nginx and php-fpm Dockerfiles)
     sync_strategy: '${DOCKER_SYNC_STRATEGY}' # for osx use 'native_osx', for windows use 'unison'
 


### PR DESCRIPTION
Fixed env variable name which points to host source directory. It seems it was broken in a0c5ef75d2cc3462af537cb3a385ccb728e585c3.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
