### PR TITLE
Upgrade PostgreSQL client to version 10.

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -682,7 +682,11 @@ ARG INSTALL_PG_CLIENT=false
 
 RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     # Install the pgsql client
-    apt-get -y install postgresql-client \
+    apt-get install wget \
+    && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update \
+    && apt-get -y install postgresql-client-10 \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so) - _not really as it wasn't necessary_.
- [] I enjoyed my time contributing and making developer's life easier :)

This PR fixes the #778 (now closed).

Details:

- workspace image uses an Ubuntu 16.04 which uses the 9.5 release as the default PostgreSQL client and server
- according to the [official PostgreSQL documentation](https://www.postgresql.org/download/linux/ubuntu/), we add their repository and then upgrade PostgreSQL client to version 10