### PR TITLE
Add log_path variable for mysql and mariadb

### DIFF
--- a/env-example
+++ b/env-example
@@ -172,6 +172,7 @@ MYSQL_PASSWORD=secret
 MYSQL_PORT=3306
 MYSQL_ROOT_PASSWORD=root
 MYSQL_ENTRYPOINT_INITDB=./mysql/docker-entrypoint-initdb.d
+MYSQL_LOG_PATH=./logs/mysql/
 
 ### REDIS #################################################
 
@@ -200,6 +201,7 @@ MARIADB_PASSWORD=secret
 MARIADB_PORT=3306
 MARIADB_ROOT_PASSWORD=root
 MARIADB_ENTRYPOINT_INITDB=./mariadb/docker-entrypoint-initdb.d
+MARIADB_LOG_PATH=./logs/mariadb/
 
 ### POSTGRES ##############################################
 


### PR DESCRIPTION
In dockerfile, mysql is using **MYSQL_LOG_PATH**.
But it's not written in **env-example**.
If user forgets to put this in **.env**, it will cause error.


<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
