### PR TITLE
Digital Ocean Docker Image comes pre-installed with Docker-Compose

### DIFF
--- a/DOCUMENTATION/content/guides/index.md
+++ b/DOCUMENTATION/content/guides/index.md
@@ -50,12 +50,6 @@ $root@server:~/laravel/ git submodule add https://github.com/Laradock/laradock.g
 $root@server:~/laravel/ cd laradock
 ```
 
-## Install docker-compose command
-
-```
-$root@server:~/laravel/laradock# curl -L https://github.com/docker/compose/releases/download/1.8.0/run.sh > /usr/local/bin/docker-compose
-$root@server:~/chmod +x /usr/local/bin/docker-compose
-```
 ##  Enter the laradock folder and rename env-example to .env.
 ```
 $root@server:~/laravel/laradock# cp env-example .env


### PR DESCRIPTION
Docker-compose is installed on a Digital Ocean Docker Image already

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)

Digital Ocean Docker Image comes pre-installed with Docker-Compose. So the part telling how to install it is no longer needed.