### PR TITLE
Enable -agree flag

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -14,4 +14,4 @@ EXPOSE 80 443 2015
 
 WORKDIR /var/www/public
 
-CMD ["/usr/bin/caddy", "-conf", "/etc/Caddyfile"]
+CMD ["/usr/bin/caddy", "-agree", "-conf", "/etc/Caddyfile"]


### PR DESCRIPTION
If this flag is not specified, it is possible that Caddy will prompt you to agree to terms during runtime. Thus, this flag is recommended in automated environments.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
