### PR TITLE
Run bash when login by `laradock` via ssh

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -33,7 +33,7 @@ ENV PGID ${PGID}
 
 RUN groupadd -g ${PGID} laradock && \
     useradd -u ${PUID} -g laradock -m laradock -G docker_env && \
-    usermod -p "*" laradock
+    usermod -p "*" laradock -s /bin/bash
 
 #
 #--------------------------------------------------------------------------


### PR DESCRIPTION
Run `bash` instead of `sh` when login via SSH by laradock user.

Also I think start directory should be `/var/www`, how we can implement it?

##### I completed the 3 steps below:

- [☑] I've read the [Contribution Guide](http://laradock.io/contributing).
- [☑] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [☑] I enjoyed my time contributing and making developer's life easier :)
