### PR TITLE
Patch/php install fails due to outdated package list

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -75,6 +75,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     mkdir -p /usr/share/man/man1 && \
     mkdir -p /usr/share/man/man7 && \
     # Install the pgsql client
+    apt-get update -yqq && \
     apt-get install -y postgresql-client \
 ;fi
 
@@ -151,6 +152,7 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 ARG INSTALL_AMQP=false
 
 RUN if [ ${INSTALL_AMQP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install librabbitmq-dev -y && \
     # Install the amqp extension
     pecl install amqp && \
@@ -187,7 +189,8 @@ ARG INSTALL_GMP=false
 
 RUN if [ ${INSTALL_GMP} = true ]; then \
     # Install the GMP extension
-	apt-get install -y libgmp-dev && \
+	apt-get update -yqq && \
+    apt-get install -y libgmp-dev && \
     docker-php-ext-install gmp \
 ;fi
 
@@ -235,6 +238,7 @@ ARG INSTALL_AEROSPIKE=false
 
 RUN if [ ${INSTALL_AEROSPIKE} = true ]; then \
     # Fix dependencies for PHPUnit within aerospike extension
+    apt-get update -yqq && \
     apt-get -y install sudo wget && \
     # Install the php aerospike extension
     curl -L -o /tmp/aerospike-client-php.tar.gz ${AEROSPIKE_PHP_REPOSITORY} \
@@ -306,6 +310,7 @@ ARG INSTALL_GHOSTSCRIPT=false
 RUN if [ ${INSTALL_GHOSTSCRIPT} = true ]; then \
     # Install the ghostscript extension
     # for PDF editing
+    apt-get update -yqq && \
     apt-get install -y \
     poppler-utils \
     ghostscript \
@@ -318,6 +323,7 @@ RUN if [ ${INSTALL_GHOSTSCRIPT} = true ]; then \
 ARG INSTALL_LDAP=false
 
 RUN if [ ${INSTALL_LDAP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y libldap2-dev && \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
     docker-php-ext-install ldap \
@@ -334,6 +340,7 @@ RUN set -eux; if [ ${INSTALL_MSSQL} = true ]; then \
     # Ref from https://github.com/Microsoft/msphpsql/wiki/Dockerfile-for-adding-pdo_sqlsrv-and-sqlsrv-to-official-php-image
     ###########################################################################
     # Add Microsoft repo for Microsoft ODBC Driver 13 for Linux
+    apt-get update -yqq && \
     apt-get install -y apt-transport-https gnupg \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/8/prod.list > /etc/apt/sources.list.d/mssql-release.list \
@@ -358,6 +365,7 @@ USER root
 ARG INSTALL_IMAGE_OPTIMIZERS=false
 
 RUN if [ ${INSTALL_IMAGE_OPTIMIZERS} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y --force-yes jpegoptim optipng pngquant gifsicle \
 ;fi
 
@@ -370,6 +378,7 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y libmagickwand-dev imagemagick && \
     pecl install imagick && \
     docker-php-ext-enable imagick \
@@ -382,6 +391,7 @@ RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
 ARG INSTALL_IMAP=false
 
 RUN if [ ${INSTALL_IMAP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y libc-client-dev libkrb5-dev && \
     rm -r /var/lib/apt/lists/* && \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -156,7 +156,8 @@ ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_SOAP} = true ]; then \
   # Install the PHP SOAP extension
-  apt-get -y install libxml2-dev php${PHP_VERSION}-soap \
+    apt-get update -yqq && \
+    apt-get -y install libxml2-dev php${PHP_VERSION}-soap \
 ;fi
 
 ###########################################################################
@@ -167,6 +168,7 @@ ARG INSTALL_LDAP=false
 ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_LDAP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y libldap2-dev && \
     apt-get install -y php${PHP_VERSION}-ldap \
 ;fi
@@ -179,6 +181,7 @@ ARG INSTALL_IMAP=false
 ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_IMAP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y php${PHP_VERSION}-imap \
 ;fi
 
@@ -193,6 +196,7 @@ ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
+    apt-get update -yqq && \
     apt-get install -y --force-yes php${PHP_VERSION}-xdebug && \
     sed -i 's/^;//g' /etc/php/${PHP_VERSION}/cli/conf.d/20-xdebug.ini && \
     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/vendor/bin/phpunit'" >> ~/.bashrc \
@@ -261,6 +265,7 @@ ARG INSTALL_AMQP=false
 ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_AMQP} = true ]; then \
+    apt-get update -yqq && \
     apt-get install librabbitmq-dev -y && \
     pecl -q install amqp && \
     echo "extension=amqp.so" >> /etc/php/${PHP_VERSION}/mods-available/amqp.ini && \
@@ -304,6 +309,7 @@ USER root
 ARG INSTALL_DRUSH=false
 
 RUN if [ ${INSTALL_DRUSH} = true ]; then \
+    apt-get update -yqq && \
     apt-get -y install mysql-client && \
     # Install Drush 8 with the phar file.
     curl -fsSL -o /usr/local/bin/drush https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar | bash && \
@@ -320,6 +326,7 @@ USER root
 ARG INSTALL_DRUPAL_CONSOLE=false
 
 RUN if [ ${INSTALL_DRUPAL_CONSOLE} = true ]; then \
+    apt-get update -yqq && \
     apt-get -y install mysql-client && \
     curl https://drupalconsole.com/installer -L -o drupal.phar && \
     mv drupal.phar /usr/local/bin/drupal && \
@@ -418,6 +425,7 @@ ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_AEROSPIKE} = true ]; then \
     # Fix dependencies for PHPUnit within aerospike extension
+    apt-get update -yqq && \
     apt-get -y install sudo wget && \
     # Install the php aerospike extension
     curl -L -o /tmp/aerospike-client-php.tar.gz ${AEROSPIKE_PHP_REPOSITORY} \
@@ -526,6 +534,7 @@ ARG INSTALL_LINUXBREW=false
 RUN if [ ${INSTALL_LINUXBREW} = true ]; then \
     # Preparation
     apt-get upgrade -y && \
+    apt-get update -yqq && \
     apt-get install -y build-essential make cmake scons curl git \
       ruby autoconf automake autoconf-archive \
       gettext libtool flex bison \
@@ -605,6 +614,7 @@ USER root
 ARG INSTALL_IMAGE_OPTIMIZERS=false
 
 RUN if [ ${INSTALL_IMAGE_OPTIMIZERS} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y --force-yes jpegoptim optipng pngquant gifsicle && \
     if [ ${INSTALL_NODE} = true ]; then \
         . ~/.bashrc && npm install -g svgo \
@@ -640,8 +650,10 @@ RUN if [ ${INSTALL_SYMFONY} = true ]; then \
 ARG INSTALL_PYTHON=false
 
 RUN if [ ${INSTALL_PYTHON} = true ]; then \
-  apt-get -y install python python-pip python-dev build-essential  \
-  && pip install --upgrade pip  \
+  apt-get update -yqq \
+  && apt-get -y install python python-pip python-dev build-essential  \
+  && pip install --upgrade pip \
+  && hash -r pip \
   && pip install --upgrade virtualenv \
 ;fi
 
@@ -654,6 +666,7 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
+    apt-get update -yqq && \
     apt-get install -y --force-yes imagemagick php-imagick \
 ;fi
 
@@ -666,6 +679,7 @@ USER root
 ARG INSTALL_TERRAFORM=false
 
 RUN if [ ${INSTALL_TERRAFORM} = true ]; then \
+    apt-get update -yqq && \
     apt-get -y install sudo wget unzip \
     && wget https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_linux_amd64.zip \
     && unzip terraform_0.10.6_linux_amd64.zip \
@@ -682,6 +696,7 @@ ARG INSTALL_PG_CLIENT=false
 
 RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     # Install the pgsql client
+    apt-get update -yqq && \
     apt-get -y install postgresql-client \
 ;fi
 
@@ -696,7 +711,8 @@ ENV CHROME_DRIVER_VERSION ${CHROME_DRIVER_VERSION}
 ARG INSTALL_DUSK_DEPS=false
 
 RUN if [ ${INSTALL_DUSK_DEPS} = true ]; then \
-  apt-get -y install zip wget unzip xdg-utils \
+  apt-get update -yqq \
+  && apt-get -y install zip wget unzip xdg-utils \
     libxpm4 libxrender1 libgtk2.0-0 libnss3 libgconf-2-4 xvfb \
     gtk2-engines-pixbuf xfonts-cyrillic xfonts-100dpi xfonts-75dpi \
     xfonts-base xfonts-scalable x11-apps \


### PR DESCRIPTION
See #1534 

Tested building containers `workspace` and `php-fpm` for PHP versions 7.2, 7.1, 7.0, and 5.6.
Fails for PHP version 5.5 with error
```bash
ERROR: Service 'workspace' failed to build: manifest for laradock/workspace:2.2-5.5 not found
```
which makes sense as there is no tagged build of `workspace` for the requested PHP version.

side issue: Is PHP 5.5 still officially supported then? There are no tags for either container `workspace` nor `php-fpm` mentioning PHP 5.5

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so). *(not applicable)*
- [x] I enjoyed my time contributing and making developer's life easier :)
