### PR TITLE
Updated `Kibana` version to match `Elasticsearch` version

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana:5.4.1
+FROM docker.elastic.co/kibana/kibana:6.2.3
 
 EXPOSE 5601


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [*] I've read the [Contribution Guide](http://laradock.io/contributing).
- [N/A] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [*] I enjoyed my time contributing and making developer's life easier :)

The current version of `Kibana` gets stuck in a redirect loop due to there being a version mismatch with `Elasticsearch`. Bumping the version to match the version of `Elasticsearch` fixes this.