### PR TITLE
Fix Laradock-Toolbox url

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -143,7 +143,7 @@ If you use Chrome 63 or above for development, don't use `.dev`. [Why?](https://
 If you are using **Docker Toolbox** (VM), do one of the following:
 
 - Upgrade to Docker [Native](https://www.docker.com/products/docker) for Mac/Windows (Recommended). Check out [Upgrading Laradock](/documentation/#upgrading-laradock)
-- Use Laradock v3.\*. Visit the [Laradock-ToolBox](https://github.com/laradock/laradock/tree/Laradock-ToolBox) branch. *(outdated)*
+- Use Laradock v3.\*. Visit the [Laradock-ToolBox](https://github.com/laradock/laradock/tree/LaraDock-ToolBox) branch. *(outdated)*
 
 <br>
 


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

PR is simply changing case on a character to make Laradock-Toolbox URL correct in docs.

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
