### PR TITLE
Fix apt-get deprecated --force-yes flag & noninteractive if needed

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -417,7 +417,7 @@ USER root
 ARG INSTALL_IMAGE_OPTIMIZERS=false
 
 RUN if [ ${INSTALL_IMAGE_OPTIMIZERS} = true ]; then \
-    apt-get install -y --force-yes jpegoptim optipng pngquant gifsicle \
+    apt-get install -y jpegoptim optipng pngquant gifsicle \
 ;fi
 
 ###########################################################################

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -18,6 +18,9 @@ FROM laradock/workspace:2.2-${PHP_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 
+# Set Environment Variables
+ENV DEBIAN_FRONTEND noninteractive
+
 # Start as root
 USER root
 
@@ -230,7 +233,7 @@ ARG PHP_VERSION=${PHP_VERSION}
 
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
-    apt-get install -y --force-yes php${PHP_VERSION}-xdebug && \
+    apt-get install -y php${PHP_VERSION}-xdebug && \
     sed -i 's/^;//g' /etc/php/${PHP_VERSION}/cli/conf.d/20-xdebug.ini && \
     echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/vendor/bin/phpunit'" >> ~/.bashrc \
 ;fi
@@ -645,7 +648,7 @@ USER root
 ARG INSTALL_IMAGE_OPTIMIZERS=false
 
 RUN if [ ${INSTALL_IMAGE_OPTIMIZERS} = true ]; then \
-    apt-get install -y --force-yes jpegoptim optipng pngquant gifsicle && \
+    apt-get install -y jpegoptim optipng pngquant gifsicle && \
     if [ ${INSTALL_NODE} = true ]; then \
         . ~/.bashrc && npm install -g svgo \
     ;fi\
@@ -694,7 +697,7 @@ USER root
 ARG INSTALL_IMAGEMAGICK=false
 
 RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
-    apt-get install -y --force-yes imagemagick php-imagick \
+    apt-get install -y imagemagick php-imagick \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
When building workspace and php-fpm images, we get the following warning:
`W: --force-yes is deprecated, use one of the options starting with --allow instead.`

More details:
```
       --force-yes
           Force yes; this is a dangerous option that will cause apt to continue without prompting if it is
           doing something potentially harmful. It should not be used except in very special situations.
           Using force-yes can potentially destroy your system! Configuration Item: APT::Get::force-yes.
           This is deprecated and replaced by --allow-downgrades, --allow-remove-essential,
           --allow-change-held-packages in 1.1.
```

In this PR we dropped the `--force-yes` usage, and enforced ** noninteractive** mode whenever needed, so it's a more clean way doing same things.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
