### PR TITLE
Fix current shell on root when installing svgo

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -661,7 +661,7 @@ ARG INSTALL_IMAGE_OPTIMIZERS=false
 RUN if [ ${INSTALL_IMAGE_OPTIMIZERS} = true ]; then \
     apt-get install -y jpegoptim optipng pngquant gifsicle && \
     if [ ${INSTALL_NODE} = true ]; then \
-        . ~/.bashrc && npm install -g svgo \
+        exec bash && . ~/.bashrc && npm install -g svgo \
     ;fi\
 ;fi
 


### PR DESCRIPTION
This fix the following errors:
```
/bin/sh: 13: /root/.bashrc: shopt: not found
/bin/sh: 21: /root/.bashrc: shopt: not found
/bin/sh: 103: /root/.bashrc: source: not found
```

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
