### PR TITLE
Fix minor syntax issue that solves "[/bin/sh: 1: [: missing ]" error

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -193,7 +193,7 @@ RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
 ###########################################################################
 
 ARG INSTALL_PCNTL=false
-RUN if [ ${INSTALL_PCNTL} = true]; then \
+RUN if [ ${INSTALL_PCNTL} = true ]; then \
     # Installs pcntl, helpful for running Horizon
     docker-php-ext-install pcntl \
 ;fi


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
