### PR TITLE
bugfix: add 'networks' to 'docker-in-docker'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -726,6 +726,8 @@ services:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
       expose:
         - 2375
+      networks:
+        - backend
 
 ### NetData ################################################
     netdata:


### PR DESCRIPTION
I do not know why but the pull request #1655 has lost the `networks` code. I'll try to insert it Insert again ;-)

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
