### PR TITLE
Fix ZipArchive not found (#481)

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -201,7 +201,7 @@ RUN if [ ${INSTALL_AMQP} = true ]; then \
 # ZipArchive:
 ###########################################################################
 
-ARG INSTALL_ZIP_ARCHIVE=false
+ARG INSTALL_ZIP_ARCHIVE=true
 
 RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
     apt-get install libzip-dev -y && \


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [ ] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [ ] I enjoyed my time contributing and making developer's life easier :)

This time is my first PR. if I have any wrong, please tell me.

This change is about the phpoffice / phpspreadsheet-based excel package like macelwebsite / excel. This error occurs when exporting .xlsx files, because php-zip is not enabled, so I changed this arg to true.