### PR TITLE
-u no longer supported

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -266,7 +266,7 @@ sub vcl_hit {
             return (deliver);
         } else {
             # No candidate for grace. Fetch a fresh object.
-            return(fetch);
+            return(miss);
         }
     } else {
     # backend is sick - use full grace
@@ -275,12 +275,12 @@ sub vcl_hit {
             return (deliver);
         } else {
             # no graced object.
-            return (fetch);
+            return (miss);
         }
     }
 
     # fetch & deliver once we get the result
-    return (fetch); # Dead code, keep as a safeguard
+    return (miss); # Dead code, keep as a safeguard
 }
 
 sub vcl_miss {

--- a/varnish/start.sh
+++ b/varnish/start.sh
@@ -11,7 +11,7 @@ exec bash -c \
     "exec varnishd \
     -a :$VARNISH_PORT \
     -T localhost:6082 \
-    -F -u varnish \
+    -F \
     -f $VARNISH_CONFIG \
     -s malloc,$CACHE_SIZE \
     $VARNISHD_PARAMS"


### PR DESCRIPTION
https://varnish-cache.org/docs/4.1/reference/varnishd.html

https://support.jpgottech.com/knowledgebase.php?article=90

issue #1732 

This may however be because debian:latest resolves to Varnish 4.1, where 6.0 is the newest version.
Also this doesn't fix everything, after removing this it throws errors coming from the default.vcl:

```
proxy_1                | Message from VCC-compiler:
compose.cli.verbose_proxy.proxy_callable: docker events -> <docker.types.daemon.CancellableStream object at 0x7fb820fb6208>
proxy_1                | Invalid return "fetch"
proxy_1                | ('/etc/varnish/default.vcl' Line 269 Pos 20)
proxy_1                |             return(fetch);
proxy_1                | -------------------#####--
proxy_1                | 
proxy_1                | 
proxy_1                | ...in subroutine "vcl_hit"
proxy_1                | ('/etc/varnish/default.vcl' Line 243 Pos 5)
proxy_1                | sub vcl_hit {
proxy_1                | ----#######--
proxy_1                | 
proxy_1                | 
proxy_1                | ...which is the "vcl_hit" method
proxy_1                | Legal returns are: "deliver" "miss" "pass" "restart" "synth"
proxy_1                | Running VCC-compiler failed, exited with 2

```

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [ ] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [ ] I enjoyed my time contributing and making developer's life easier :)
