### PR TITLE
Enable `docker-compose exec workspace npm` (and yarn, etc.)

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -478,6 +478,9 @@ RUN if [ ${INSTALL_YARN} = true ]; then \
     echo 'export PATH="$YARN_DIR/bin:$PATH"' >> ~/.bashrc \
 ;fi
 
+# Add PATH for YARN
+ENV PATH $PATH:/home/laradock/.yarn/bin
+
 ###########################################################################
 # PHP Aerospike:
 ###########################################################################

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -421,6 +421,7 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
         && if [ ${INSTALL_NPM_VUE_CLI} = true ]; then \
         npm install -g @vue/cli \
         ;fi \
+        && ln -s `npm bin --global` /home/laradock/.node-bin \
 ;fi
 
 # Wouldn't execute when added to the RUN statement in the above block
@@ -441,7 +442,7 @@ RUN if [ ${INSTALL_NODE} = true ]; then \
 ;fi
 
 # Add PATH for node
-ENV PATH $PATH:$NVM_DIR/versions/node/v${NODE_VERSION}/bin
+ENV PATH $PATH:/home/laradock/.node-bin
 
 RUN if [ ${NPM_REGISTRY} ]; then \
     . ~/.bashrc && npm config set registry ${NPM_REGISTRY} \


### PR DESCRIPTION
fixes #1352 

This fix corrects PATH to point nvm and yarn directory  so that we can run `docker-compose exec workspace npm` directly.
It enables to run node, yarn, npm and global installed npm packages by using `docker-compose exec`.

As the problem described in the issue #1352 , `$NVM_DIR/versions/node/v${NODE_VERSION}/bin` is not always the correct path for node.
We can get the bin directory path by running `npm bin --global`, but it is not allowed to run some commands in ENV statements.
so I created a symbolic link `.node-bin` to point the bin directory and fix the PATH to see there.

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
