### PR TITLE
Fix Caddy file path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -480,7 +480,7 @@ services:
       build: ./caddy
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
-        - ${CADDY_CONFIG_PATH}:/etc/caddy
+        - ${CADDY_CONFIG_PATH}:/etc
         - ${CADDY_HOST_LOG_PATH}:/var/log/caddy
         - ${DATA_PATH_HOST}:/root/.caddy
       ports:


### PR DESCRIPTION
Since caddy container is used from alpine.
The default path of caddy configuration in alpine is /etc/Caddy  (Not /etc/caddy/Caddy

Error:
caddy_1                | http plugins loaded: git
caddy_1                | 2018/09/26 07:21:34 loading Caddyfile via flag: open /etc/Caddyfile: no such file or directory

Fix Caddy configuration volume path

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
