### PR TITLE
FROM must to be the first instructions. Fixing error with docker-comp…

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,5 +1,6 @@
-ARG MYSQL_VERSION=latest
 FROM mysql:${MYSQL_VERSION}
+
+ARG MYSQL_VERSION=latest
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -12,8 +12,6 @@
 # Note: Base Image name format {image-tag}-{php-version}
 #
 
-ARG LARADOCK_PHP_VERSION
-
 FROM laradock/workspace:2.2-${LARADOCK_PHP_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
@@ -816,7 +814,7 @@ RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
 USER root
 
 RUN apt-get update -yqq \
-    && apt-get -yqq install nasm 
+    && apt-get -yqq install nasm
 
 ###########################################################################
 # Dusk Dependencies:


### PR DESCRIPTION
Hi,

I was having problems running the docker-compose.yml file, I was getting two errors in the mysql Dockerfile and the workspace Dockerfile. 

- MySQL: In this case the FROM instruction was not the first instruction as it has to be.
- Workspace: In this case the instruction ARG LARADOCK_PHP_VERSION was duplicated and avoiding the FROM instruction be the first instruction.

Hope this change can be helpful.

Thank you for all your hard work.