### PR TITLE
Fix php5.6 workspace aerospike travis-ci build failed

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -540,22 +540,10 @@ RUN if [ ${INSTALL_AEROSPIKE} = true ]; then \
     curl -L -o /tmp/aerospike-client-php.tar.gz ${AEROSPIKE_PHP_REPOSITORY} \
     && mkdir -p aerospike-client-php \
     && tar -C aerospike-client-php -zxvf /tmp/aerospike-client-php.tar.gz --strip 1 \
-    && \
-      if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
-        ( \
-            cd aerospike-client-php/src/aerospike \
-            && phpize \
-            && ./build.sh \
-            && make install \
-        ) \
-      else \
-        ( \
-            cd aerospike-client-php/src \
-            && phpize \
-            && ./build.sh \
-            && make install \
-        ) \
-      fi \
+    && cd aerospike-client-php/src/aerospike \
+    && phpize \
+    && ./build.sh \
+    && make install \
     && rm /tmp/aerospike-client-php.tar.gz \
     && echo 'extension=aerospike.so' >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/aerospike.ini \
     && echo 'aerospike.udf.lua_system_path=/usr/local/aerospike/lua' >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/aerospike.ini \


### PR DESCRIPTION
https://github.com/aerospike/aerospike-client-php/archive/7.2.0-release-candidate.tar.gz for php 7.2 and https://github.com/aerospike/aerospike-client-php5/archive/3.4.15.tar.gz for php 5.6 has `config.m4` exist into `src/aerospike` directory

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
