### PR TITLE
Remove duplicated docker-sync-strategy

### DIFF
--- a/env-example
+++ b/env-example
@@ -372,14 +372,6 @@ CADDY_CONFIG_PATH=./caddy/caddy
 
 LARAVEL_ECHO_SERVER_PORT=6001
 
-### DOCKER-SYNC ########################################################################################################
-
-# osx: 'native_osx' (default)
-# windows: 'unison'
-# linux: docker-sync not required
-
-DOCKER_SYNC_STRATEGY=native_osx
-
 ### THUMBOR ############################################################################################################
 
 THUMBOR_PORT=8000


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

Removed the duplicate DOCKER_SYNC_STRATEGY values from env-example that was unnecessarily added in the Thumbor merge via PR #1373 

I note the existing PR #1833, but that one removes the original value which is higher up in the file in the general setup area, and thus more visible and appropriately placed for developers tweaking their config, as opposed to this duplicated entry which appears near the middle of the file in the container configuration options, and you'd have to know about it to change it.

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
