### PR TITLE
Update default user for workspace container

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -875,12 +875,12 @@ RUN php -v | head -n 1 | grep -q "PHP ${LARADOCK_PHP_VERSION}."
 #--------------------------------------------------------------------------
 #
 
-USER root
-
 # Clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     rm /var/log/lastlog /var/log/faillog
+
+USER laradock
 
 # Set default work directory
 WORKDIR /var/www


### PR DESCRIPTION
Log for Laravel is from 3 sources:
1/ From web activities:
when there is no log file (for ex, in daily rotated log), owner of log file will be laradock: OK

2/ From CRON:
when there is no log file, owner of log file will be laradock: OK

3/ From artisan commands (manually):
when there is no log file, owner of log file will be root (because default user of workspace is root user): NOT OK.

==> I create this PR to set default user for workspace is laradock.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
