### PR TITLE
Fix issue 1874

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
           - INSTALL_PGSQL=${PHP_WORKER_INSTALL_PGSQL}
           - INSTALL_BCMATH=${PHP_WORKER_INSTALL_BCMATH}
           - INSTALL_SOAP=${PHP_WORKER_INSTALL_SOAP}
+          - INSTALL_ZIP_ARCHIVE=${PHP_WORKER_INSTALL_ZIP_ARCHIVE}
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
         - ./php-worker/supervisord.d:/etc/supervisord.d

--- a/env-example
+++ b/env-example
@@ -169,6 +169,7 @@ PHP_FPM_INSTALL_YAML=false
 PHP_WORKER_INSTALL_PGSQL=false
 PHP_WORKER_INSTALL_BCMATH=false
 PHP_WORKER_INSTALL_SOAP=false
+PHP_WORKER_INSTALL_ZIP_ARCHIVE=false
 
 ### NGINX #################################################
 

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -44,6 +44,15 @@ RUN if [ ${INSTALL_PGSQL} = true ]; then \
         && docker-php-ext-install pdo_pgsql \
 ;fi
 
+# Install ZipArchive:
+ARG INSTALL_ZIP_ARCHIVE=false
+RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
+    apk --update add libzip-dev && \
+    docker-php-ext-configure zip --with-libzip && \
+    # Install the zip extension
+    docker-php-ext-install zip \
+;fi
+
 RUN rm /var/cache/apk/* \
     && mkdir -p /var/www
 


### PR DESCRIPTION
Fix #1874 

1. Update Dockerfile of php-worker to support installing zip extension
2. Update docker-compose.yml to have new argument INSTALL_ZIP_ARCHIVE
3. Update env-example to have default value for PHP_WORKER_INSTALL_ZIP_ARCHIVE
4. Test again, it works.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
