### PR TITLE
Fix issue where `MYSQL_VERSION` cannot be overridden via `.env` file

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-ARG MYSQL_VERSION=latest
+ARG MYSQL_VERSION
 FROM mysql:${MYSQL_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"


### PR DESCRIPTION
This PR contains a very minor change to remove hardcoded value of `MYSQL_VERSION` in Dockerfile to allow it be overridden via an environment variable.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
