### PR TITLE
`apt-get update` needs to be run for mssql to work properly

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -450,7 +450,7 @@ RUN set -eux; if [ ${INSTALL_MSSQL} = true ]; then \
       # Ref from https://github.com/Microsoft/msphpsql/wiki/Dockerfile-for-adding-pdo_sqlsrv-and-sqlsrv-to-official-php-image
       ###########################################################################
       # Add Microsoft repo for Microsoft ODBC Driver 13 for Linux
-      apt-get install -y apt-transport-https gnupg \
+      apt-get update && apt-get install -y apt-transport-https gnupg \
       && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
       && curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list \
       && apt-get update -yqq \


### PR DESCRIPTION
Hi,

We found that `apt-get update` needs to be run before pulling in `apt-transport-https` otherwise `pdo_sqlsrv` won't be added successfully.