### PR TITLE
Typo in PHP_VERSION (It should be LARADOCK_PHP_VERSION) for PHP gmp extension in workspace container Dockerfile

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -194,11 +194,11 @@ RUN if [ ${INSTALL_SSH2} = true ]; then \
 USER root
 
 ARG INSTALL_GMP=false
-ARG PHP_VERSION=${PHP_VERSION}
+ARG PHP_VERSION=${LARADOCK_PHP_VERSION}
 
 RUN if [ ${INSTALL_GMP} = true ]; then \
   # Install the PHP GMP extension
-  apt-get -y install php${PHP_VERSION}-gmp \
+  apt-get -y install php${LARADOCK_PHP_VERSION}-gmp \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)


