### PR TITLE
modify syntax error

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -550,6 +550,7 @@ ARG INSTALL_APCU=false
 RUN if [ ${INSTALL_APCU} = true ]; then \
     pecl install apcu && \
     docker-php-ext-enable apcu \
+;fi
 
 ###########################################################################
 # YAML:


### PR DESCRIPTION
Syntax error in shell when installing APCU.
Because Fixed shell syntax.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
