### PR TITLE
using Alpine for Beanstalkd and RabbitMQ, list all ports exposed for RabbitMQ

### DIFF
--- a/beanstalkd/Dockerfile
+++ b/beanstalkd/Dockerfile
@@ -1,16 +1,7 @@
-FROM phusion/baseimage:latest
-
+FROM alpine
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-RUN apt-get update
-RUN apt-get install -y beanstalkd
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-VOLUME /var/lib/beanstalkd/data
+RUN apk add --no-cache beanstalkd
 
 EXPOSE 11300
-
-CMD ["/usr/bin/beanstalkd"]
+ENTRYPOINT ["/usr/bin/beanstalkd"]

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,7 +1,7 @@
-FROM rabbitmq
+FROM rabbitmq:alpine
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
-EXPOSE 15671 15672
+EXPOSE 4369 5671 5672 15671 15672 25672


### PR DESCRIPTION
1. Use Alpine for Beanstalkd image
2. Use Alpine for RabbitMQ image
3. Update EXPOSE to list all ports of RabbitMQ

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
