### PR TITLE
persistent RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -503,6 +503,9 @@ services:
       environment:
         - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
         - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+      hostname: laradock-rabbitmq
+      volumes:
+        - ${DATA_PATH_HOST}/rabbitmq:/var/lib/rabbitmq
       depends_on:
         - php-fpm
       networks:


### PR DESCRIPTION
1. add hostname and volume for RabbitMQ, so that it can be persistent.
+ reason to add hostname: because name of folder containing data of RabbitMQ depends on hostname, in order to keep it persistent, we need to have same hostname.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
