### PR TITLE
fix build Solr, failed in https://travis-ci.org/laradock/laradock/jobs/479960032

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -18,7 +18,7 @@ ENV SOLR_DATAIMPORTHANDLER_MSSQL ${SOLR_DATAIMPORTHANDLER_MSSQL}
 # download mssql connector for dataimporthandler
 RUN if [ ${SOLR_DATAIMPORTHANDLER_MSSQL} = true ]; then \
     curl -L -o /tmp/mssql-jdbc-7.0.0.jre8.jar "https://github.com/Microsoft/mssql-jdbc/releases/download/v7.0.0/mssql-jdbc-7.0.0.jre8.jar" \
-       && mkdir /opt/solr/contrib/dataimporthandler/lib \
+       && mkdir -p /opt/solr/contrib/dataimporthandler/lib \
        && mv /tmp/mssql-jdbc-7.0.0.jre8.jar "/opt/solr/contrib/dataimporthandler/lib/mssql-jdbc-7.0.0.jre8.jar" \
 ;fi
 


### PR DESCRIPTION
see that job https://travis-ci.org/laradock/laradock/jobs/479960032 failed, fix it.

new folder `/opt/solr/contrib/dataimporthandler/lib` occurs in mkdir twice, so using `mkdir -p` to prevent error if it already existed.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
