### PR TITLE
fix php-fpm build for 5.6, 7.0 and 7.1

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -221,7 +221,16 @@ RUN if [ ${INSTALL_MONGO} = true ]; then \
 ARG INSTALL_AMQP=false
 
 RUN if [ ${INSTALL_AMQP} = true ]; then \
-    apt-get install librabbitmq-dev -y && \
+    # download and install manually, to make sure it's compatible with ampq installed by pecl later
+    # install cmake first
+    apt-get update && apt-get -y install cmake && \
+    curl -L -o /tmp/rabbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/master.tar.gz && \
+    mkdir -p rabbitmq-c && \
+    tar -C rabbitmq-c -zxvf /tmp/rabbitmq-c.tar.gz --strip 1 && \
+    cd rabbitmq-c/ && \
+    mkdir _build && cd _build/ && \
+    cmake .. && \
+    cmake --build . --target install && \
     # Install the amqp extension
     pecl install amqp && \
     docker-php-ext-enable amqp && \
@@ -550,7 +559,11 @@ RUN if [ $INSTALL_PHALCON = true ]; then \
 ARG INSTALL_APCU=false
 
 RUN if [ ${INSTALL_APCU} = true ]; then \
-    pecl install apcu && \
+    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
+        pecl install -a apcu-4.0.11; \
+    else \
+        pecl install apcu; \
+    fi && \
     docker-php-ext-enable apcu \
 ;fi
 
@@ -564,7 +577,11 @@ ARG INSTALL_YAML=false
 
 RUN if [ ${INSTALL_YAML} = true ]; then \
     apt-get install libyaml-dev -y ; \
-    pecl install yaml ; \
+    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
+        pecl install -a yaml-1.3.2; \
+    else \
+        pecl install yaml; \
+    fi && \
     docker-php-ext-enable yaml \
 ;fi
 


### PR DESCRIPTION
Fix php-fpm build for PHP version 5.6, 7.0 and 7.1

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
