### PR TITLE
fix adminer INSTALL_MSSQL build fail.

### DIFF
--- a/adminer/Dockerfile
+++ b/adminer/Dockerfile
@@ -13,11 +13,15 @@ ARG INSTALL_MSSQL=false
 ENV INSTALL_MSSQL ${INSTALL_MSSQL}
 RUN if [ ${INSTALL_MSSQL} = true ]; then \
   set -xe \
-  && apk --update add --no-cache --virtual .phpize-deps $PHPIZE_DEPS unixodbc unixodbc-dev \
-  && pecl channel-update pecl.php.net \
-  && pecl install pdo_sqlsrv-4.1.8preview sqlsrv-4.1.8preview \
-  && echo "extension=sqlsrv.so" > /usr/local/etc/php/conf.d/20-sqlsrv.ini \
-  && echo "extension=pdo_sqlsrv.so" > /usr/local/etc/php/conf.d/20-pdo_sqlsrv.ini \
+  # && apk --update add --no-cache --virtual .phpize-deps $PHPIZE_DEPS unixodbc unixodbc-dev \
+  # && pecl channel-update pecl.php.net \
+  # && pecl install pdo_sqlsrv-4.1.8preview sqlsrv-4.1.8preview \
+  # && echo "extension=sqlsrv.so" > /usr/local/etc/php/conf.d/20-sqlsrv.ini \
+  # && echo "extension=pdo_sqlsrv.so" > /usr/local/etc/php/conf.d/20-pdo_sqlsrv.ini \
+  && apk --update add --no-cache freetds unixodbc \
+  && apk --update add --no-cache --virtual .build-deps $PHPIZE_DEPS freetds-dev unixodbc-dev \
+  && docker-php-ext-install pdo_dblib \
+  && apk del .build-deps \
 ;fi
 
 USER adminer


### PR DESCRIPTION
1. adminer:4 now use php 7.3, but extension sqlsrv and pdo_sqlsrv not support.
2. add pdo_dblib to support mssql.