### PR TITLE
update adminer to support SQL Server

### DIFF
--- a/adminer/Dockerfile
+++ b/adminer/Dockerfile
@@ -9,19 +9,19 @@ VOLUME /sessions
 # SQL SERVER:
 #####################################
 USER root
+
 ARG INSTALL_MSSQL=false
 ENV INSTALL_MSSQL ${INSTALL_MSSQL}
+
 RUN if [ ${INSTALL_MSSQL} = true ]; then \
   set -xe \
-  # && apk --update add --no-cache --virtual .phpize-deps $PHPIZE_DEPS unixodbc unixodbc-dev \
-  # && pecl channel-update pecl.php.net \
-  # && pecl install pdo_sqlsrv-4.1.8preview sqlsrv-4.1.8preview \
-  # && echo "extension=sqlsrv.so" > /usr/local/etc/php/conf.d/20-sqlsrv.ini \
-  # && echo "extension=pdo_sqlsrv.so" > /usr/local/etc/php/conf.d/20-pdo_sqlsrv.ini \
-  && apk --update add --no-cache freetds unixodbc \
-  && apk --update add --no-cache --virtual .build-deps $PHPIZE_DEPS freetds-dev unixodbc-dev \
-  && docker-php-ext-install pdo_dblib \
-  && apk del .build-deps \
+  && apk update \
+  && apk add --no-cache --virtual .php-build-dependencies unixodbc-dev freetds-dev \
+  && apk add --virtual .php-runtime-dependencies unixodbc freetds \
+  && docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
+  && docker-php-ext-install pdo_odbc pdo_dblib \
+  && apk del .php-build-dependencies \
+  && rm -rf /var/cache/apk/* \
 ;fi
 
 USER adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,7 +359,7 @@ services:
         - SA_PASSWORD=${MSSQL_PASSWORD}
         - ACCEPT_EULA=Y
       volumes:
-        - ${DATA_PATH_HOST}/mssql:/var/opt/mssql
+        - mssql:/var/opt/mssql
       ports:
         - "${MSSQL_PORT}:1433"
       networks:


### PR DESCRIPTION
Update adminer to suport SQL Server:
1. Use mssql volume, don't use data volume
2. Use latest version of pdo_sqlsrv
3. Already checked and worked well with mssql container

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [ x I enjoyed my time contributing and making developer's life easier :)
