### PR TITLE
setup auth plugin to native password by default

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,3 +8,4 @@
 [mysqld]
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
+default_authentication_plugin=mysql_native_password


### PR DESCRIPTION
Access denied for user defined in .env in MySQL 8
#1694

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [*] I've read the [Contribution Guide](http://laradock.io/contributing).
- [*] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [*] I enjoyed my time contributing and making developer's life easier :)
