### PR TITLE
Set 'logrotate' for 'nginx' logs

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -22,8 +22,11 @@ RUN apk update \
 ARG PHP_UPSTREAM_CONTAINER=php-fpm
 ARG PHP_UPSTREAM_PORT=9000
 
-# create 'messages' file used from 'logrotate'
+# Create 'messages' file used from 'logrotate'
 RUN touch /var/log/messages
+
+# Copy 'logrotate' config file
+COPY logrotate/nginx /etc/logrotate.d/
 
 # Set upstream conf and remove the default conf
 RUN echo "upstream php-upstream { server ${PHP_UPSTREAM_CONTAINER}:${PHP_UPSTREAM_PORT}; }" > /etc/nginx/conf.d/upstream.conf \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -14,12 +14,16 @@ RUN if [ ${CHANGE_SOURCE} = true ]; then \
 
 RUN apk update \
     && apk upgrade \
+    && apk --update add logrotate \
     && apk add --no-cache openssl \
     && apk add --no-cache bash \
     && adduser -D -H -u 1000 -s /bin/bash www-data
 
 ARG PHP_UPSTREAM_CONTAINER=php-fpm
 ARG PHP_UPSTREAM_PORT=9000
+
+# create 'messages' file used from 'logrotate'
+RUN touch /var/log/messages
 
 # Set upstream conf and remove the default conf
 RUN echo "upstream php-upstream { server ${PHP_UPSTREAM_CONTAINER}:${PHP_UPSTREAM_PORT}; }" > /etc/nginx/conf.d/upstream.conf \

--- a/nginx/logrotate/nginx
+++ b/nginx/logrotate/nginx
@@ -6,7 +6,7 @@
         delaycompress
         nodateext
         notifempty
-        create 640 root root
+        create 644 www-data root
         sharedscripts
         postrotate
                 [ -f /var/run/nginx.pid ] && kill -USR1 `cat /var/run/nginx.pid`

--- a/nginx/logrotate/nginx
+++ b/nginx/logrotate/nginx
@@ -4,6 +4,7 @@
         rotate 32
         compress
         delaycompress
+        nodateext
         notifempty
         create 640 root root
         sharedscripts

--- a/nginx/logrotate/nginx
+++ b/nginx/logrotate/nginx
@@ -1,0 +1,13 @@
+/var/log/nginx/*.log {
+        daily
+        missingok
+        rotate 32
+        compress
+        delaycompress
+        notifempty
+        create 640 root root
+        sharedscripts
+        postrotate
+                [ -f /var/run/nginx.pid ] && kill -USR1 `cat /var/run/nginx.pid`
+        endscript
+}

--- a/nginx/startup.sh
+++ b/nginx/startup.sh
@@ -6,4 +6,8 @@ if [ ! -f /etc/nginx/ssl/default.crt ]; then
     openssl x509 -req -days 365 -in "/etc/nginx/ssl/default.csr" -signkey "/etc/nginx/ssl/default.key" -out "/etc/nginx/ssl/default.crt"
 fi
 
+# Start crond in background
+crond -l 2 -b
+
+# Start nginx in foreground
 nginx


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)

Add `logrotate` to **nginx** logs file stored in `logs/nginx`). 

Issue https://github.com/laradock/laradock/issues/1357