### PR TITLE
Cannot load Xdebug - it was already loaded

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -310,8 +310,7 @@ ARG INSTALL_XDEBUG=false
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
     apt-get install -y php${LARADOCK_PHP_VERSION}-xdebug && \
-    sed -i 's/^;//g' /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/20-xdebug.ini && \
-    echo "alias phpunit='php -dzend_extension=xdebug.so /var/www/vendor/bin/phpunit'" >> ~/.bashrc \
+    sed -i 's/^;//g' /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/20-xdebug.ini \
 ;fi
 
 # ADD for REMOTE debugging


### PR DESCRIPTION
xdebug.so is probably already activated in `20-xdebug.ini` so there's no need to override the phpunit alias

also `/var/www/vendor/bin/phpunit` instead of `./vendor/bin/phpunit` breaks phpunit, pu, puf and pud when vendor folder is not in root app directory

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
