### PR TITLE
Fixed warning about tideways.so not loaded if INSTALL_XHRPOF=false in .env

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -278,9 +278,10 @@ RUN if [ ${INSTALL_XHPROF} = true ]; then \
     ) \
     && rm -r xhprof \
     && rm /tmp/xhprof.tar.gz \
+    && COPY ./xhprof.ini /usr/local/etc/php/conf.d \
 ;fi
 
-COPY ./xhprof.ini /usr/local/etc/php/conf.d
+
 
 ###########################################################################
 # AMQP:


### PR DESCRIPTION
A fix to #2169 :

Each PHP execution returns a warning about missing tideways.so extension (used for XHPROF), when INSTALL_XHPROF=false in .env:
`PHP Warning: PHP Startup: Unable to load dynamic library 'tideways.so'`

You can check this just using:
```
$ cd laradock
$ ./php-fpm/xdebug status
```
(There is no documentation about INSTALL_XHRPOF setting, so no update to docs provided)

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
