### PR TITLE
Update to Elasticsearch 7.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -664,7 +664,7 @@ services:
         - node.name=laradock-node
         - bootstrap.memory_lock=true
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-        - "cluster.initial_master_nodes=laradock-node"
+        - cluster.initial_master_nodes=laradock-node
       ulimits:
         memlock:
           soft: -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -661,8 +661,10 @@ services:
         - elasticsearch:/usr/share/elasticsearch/data
       environment:
         - cluster.name=laradock-cluster
+        - node.name=laradock-node
         - bootstrap.memory_lock=true
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        - "cluster.initial_master_nodes=laradock-node"
       ulimits:
         memlock:
           soft: -1

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.1.1
 
 EXPOSE 9200 9300


### PR DESCRIPTION
Hi, 

I have updated Elasticsearch to the 7.1.1 version. I added in the docker-compose file two environnement variables that need to be there because of [breaking compatibilities](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_discovery_changes)

Hope this is useful for others.

Best regards,
Guillaume R.
