### PR TITLE
fix:  exec: zookeeper: not found

### DIFF
--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -7,4 +7,4 @@ VOLUME /datalog
 
 EXPOSE 2181
 
-CMD ["zookeeper"]
+CMD ["zkServer.sh", "start-foreground"]


### PR DESCRIPTION
refer to [Zookeeper latest 3.5.5 Dockerfile](https://github.com/31z4/zookeeper-docker/blob/c978f835bc33509324b51cb210c8c5c9934c38ff/3.5.5/Dockerfile)

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
