### PR TITLE
gcloud registry auth step for docker build

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -8,6 +8,7 @@ weight: 2
 
 - [Git](https://git-scm.com/downloads)
 - [Docker](https://www.docker.com/products/docker/) `>= 17.12`
+- [gcloud](https://cloud.google.com/sdk/install) 
 
 
 
@@ -24,6 +25,17 @@ Choose the setup the best suits your needs.
  	- [A.2) Don't have a PHP project yet](#A2)
 - [B) Setup for Multiple Projects](#B)
 
+### Setup gcloud for docker registry
+
+```
+gcloud auth configure-docker
+```
+
+and login to gcloud for use the registry and auth the permission.
+
+```
+gcloud auth login
+```
 
 <a name="A"></a>
 ### A) Setup for Single Project


### PR DESCRIPTION
nowaday, the docker image build from gcloud registry, so you need auth the configure and login the gcloud first to build the docker image.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [v] I've read the [Contribution Guide](http://laradock.io/contributing).
- [v] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [v] I enjoyed my time contributing and making developer's life easier :)
