### PR TITLE
Added possibility of configure PUID for PHP-FPM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,7 @@ services:
           - ADDITIONAL_LOCALES=${PHP_FPM_ADDITIONAL_LOCALES}
           - INSTALL_FFMPEG=${PHP_FPM_FFMPEG}
           - INSTALL_XHPROF=${PHP_FPM_INSTALL_XHPROF}
+          - PUID=${PHP_FPM_PUID}
           - http_proxy
           - https_proxy
           - no_proxy

--- a/env-example
+++ b/env-example
@@ -192,6 +192,7 @@ PHP_FPM_INSTALL_PING=false
 PHP_FPM_INSTALL_SSHPASS=false
 PHP_FPM_FFMPEG=false
 PHP_FPM_ADDITIONAL_LOCALES="es_ES.UTF-8 fr_FR.UTF-8"
+PHP_FPM_PUID=1000
 
 ### PHP_WORKER ############################################
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -749,7 +749,10 @@ RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     rm /var/log/lastlog /var/log/faillog
 
-RUN usermod -u 1000 www-data
+ARG PUID=1000
+ENV PUID=${PUID}
+
+RUN usermod -u ${PUID} www-data
 
 # Adding the faketime library to the preload file needs to be done last
 # otherwise it will preload it for all commands that follow in this file


### PR DESCRIPTION
It could be useful in case one deploys on remote where are several users and a project already rolled out by user that has id of not 1000; then PHP can't work with FS properly. It possible to change PUID right in Dockerfile, but probably better have a possibility to do it in .env

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
