### PR TITLE
laravel-horizon: Install 'sockets' without install 'AMQP`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
           - INSTALL_PGSQL=${PHP_FPM_INSTALL_PGSQL}
           - INSTALL_BCMATH=${PHP_FPM_INSTALL_BCMATH}
           - INSTALL_MEMCACHED=${PHP_FPM_INSTALL_MEMCACHED}
-          - INSTALL_AMQP=${PHP_FPM_INSTALL_AMQP}
+          - INSTALL_SOCKETS=${LARAVEL_HORIZON_INSTALL_SOCKETS}
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
         - ./laravel-horizon/supervisord.d:/etc/supervisord.d

--- a/env-example
+++ b/env-example
@@ -219,6 +219,10 @@ NGINX_PHP_UPSTREAM_CONTAINER=php-fpm
 NGINX_PHP_UPSTREAM_PORT=9000
 NGINX_SSL_PATH=./nginx/ssl/
 
+### LARAVEL_HORIZON ################################################
+
+LARAVEL_HORIZON_INSTALL_SOCKETS=false
+
 ### APACHE ################################################
 
 APACHE_HOST_HTTP_PORT=80

--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -33,8 +33,8 @@ RUN if [ ${INSTALL_BCMATH} = true ]; then \
   ;fi
 
 #Install Sockets package:
-ARG INSTALL_AMQP=false
-RUN if [ ${INSTALL_AMQP} = true ]; then \
+ARG INSTALL_SOCKETS=false
+RUN if [ ${INSTALL_SOCKETS} = true ]; then \
   docker-php-ext-install sockets \
   ;fi
 


### PR DESCRIPTION
As described here #2209 , in `laravel-horizon` I can install `sockets` without installing all `AMQP`.

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)