### PR TITLE
Implement Cassandra DB & PHP Extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
 
     - PHP_VERSION=NA BUILD_SERVICE=solr
     - PHP_VERSION=NA BUILD_SERVICE="mssql rethinkdb aerospike"
-    - PHP_VERSION=NA BUILD_SERVICE="blackfire minio percona nginx caddy apache2 mysql mariadb postgres postgres-postgis neo4j mongo redis"
+    - PHP_VERSION=NA BUILD_SERVICE="blackfire minio percona nginx caddy apache2 mysql mariadb postgres postgres-postgis neo4j mongo redis cassandra"
     - PHP_VERSION=NA BUILD_SERVICE="adminer phpmyadmin pgadmin"
     - PHP_VERSION=NA BUILD_SERVICE="memcached beanstalkd beanstalkd-console rabbitmq elasticsearch certbot mailhog maildev selenium jenkins proxy proxy2 haproxy"
     - PHP_VERSION=NA BUILD_SERVICE="kibana grafana laravel-echo-server"

--- a/DOCUMENTATION/content/introduction/index.md
+++ b/DOCUMENTATION/content/introduction/index.md
@@ -125,6 +125,7 @@ That's it! enjoy :)
     - Neo4j
     - CouchDB
     - RethinkDB 
+    - Cassandra
 
 
 - **Database Management Apps:**

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -1,0 +1,5 @@
+ARG CASSANDRA_VERSION=latest
+FROM bitnami/cassandra:${CASSANDRA_VERSION}
+
+LABEL maintainer="Stefan Neuhaus <https://www.github.com/stefnats>"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   sonarqube:
     driver: ${VOLUMES_DRIVER}
+  cassandra:
+    driver: ${VOLUMES_DRIVER}
 
 services:
 
@@ -67,6 +69,7 @@ services:
           - INSTALL_IMAP=${WORKSPACE_INSTALL_IMAP}
           - INSTALL_MONGO=${WORKSPACE_INSTALL_MONGO}
           - INSTALL_AMQP=${WORKSPACE_INSTALL_AMQP}
+          - INSTALL_CASSANDRA=${WORKSPACE_INSTALL_CASSANDRA}
           - INSTALL_PHPREDIS=${WORKSPACE_INSTALL_PHPREDIS}
           - INSTALL_MSSQL=${WORKSPACE_INSTALL_MSSQL}
           - INSTALL_NODE=${WORKSPACE_INSTALL_NODE}
@@ -153,6 +156,7 @@ services:
           - INSTALL_IMAP=${PHP_FPM_INSTALL_IMAP}
           - INSTALL_MONGO=${PHP_FPM_INSTALL_MONGO}
           - INSTALL_AMQP=${PHP_FPM_INSTALL_AMQP}
+          - INSTALL_CASSANDRA=${PHP_FPM_INSTALL_CASSANDRA}
           - INSTALL_MSSQL=${PHP_FPM_INSTALL_MSSQL}
           - INSTALL_BCMATH=${PHP_FPM_INSTALL_BCMATH}
           - INSTALL_GMP=${PHP_FPM_INSTALL_GMP}
@@ -220,6 +224,7 @@ services:
           - INSTALL_ZIP_ARCHIVE=${PHP_WORKER_INSTALL_ZIP_ARCHIVE}
           - INSTALL_MYSQL_CLIENT=${PHP_WORKER_INSTALL_MYSQL_CLIENT}
           - INSTALL_AMQP=${PHP_WORKER_INSTALL_AMQP}
+          - INSTALL_CASSANDRA=${PHP_WORKER_INSTALL_CASSANDRA}
           - INSTALL_GHOSTSCRIPT=${PHP_WORKER_INSTALL_GHOSTSCRIPT}
           - INSTALL_SWOOLE=${PHP_WORKER_INSTALL_SWOOLE}
           - INSTALL_TAINT=${PHP_WORKER_INSTALL_TAINT}
@@ -246,6 +251,7 @@ services:
           - INSTALL_BCMATH=${PHP_FPM_INSTALL_BCMATH}
           - INSTALL_MEMCACHED=${PHP_FPM_INSTALL_MEMCACHED}
           - INSTALL_AMQP=${PHP_FPM_INSTALL_AMQP}
+          - INSTALL_CASSANDRA=${PHP_FPM_INSTALL_CASSANDRA}
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
         - ./laravel-horizon/supervisord.d:/etc/supervisord.d
@@ -579,6 +585,38 @@ services:
       hostname: laradock-rabbitmq
       volumes:
         - ${DATA_PATH_HOST}/rabbitmq:/var/lib/rabbitmq
+      depends_on:
+        - php-fpm
+      networks:
+        - backend
+
+### Cassandra ############################################
+    cassandra:
+      build: ./cassandra
+      ports:
+        - "${CASSANDRA_TRANSPORT_PORT_NUMBER}:7000"
+        - "${CASSANDRA_JMX_PORT_NUMBER}:7199"
+        - "${CASSANDRA_CQL_PORT_NUMBER}:9042"
+      privileged: true
+      environment:
+        - CASSANDRA_VERSION=${CASSANDRA_VERSION}
+        - CASSANDRA_TRANSPORT_PORT_NUMBER=${CASSANDRA_TRANSPORT_PORT_NUMBER}
+        - CASSANDRA_JMX_PORT_NUMBER=${CASSANDRA_JMX_PORT_NUMBER}
+        - CASSANDRA_CQL_PORT_NUMBER=${CASSANDRA_CQL_PORT_NUMBER}
+        - CASSANDRA_USER=${CASSANDRA_USER}
+        - CASSANDRA_PASSWORD_SEEDER=${CASSANDRA_PASSWORD_SEEDER}
+        - CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}
+        - CASSANDRA_NUM_TOKENS=${CASSANDRA_NUM_TOKENS}
+        - CASSANDRA_HOST=${CASSANDRA_HOST}
+        - CASSANDRA_CLUSTER_NAME=${CASSANDRA_CLUSTER_NAME}
+        - CASSANDRA_SEEDS=${CASSANDRA_SEEDS}
+        - CASSANDRA_ENDPOINT_SNITCH=${CASSANDRA_ENDPOINT_SNITCH}
+        - CASSANDRA_ENABLE_RPC=${CASSANDRA_ENABLE_RPC}
+        - CASSANDRA_DATACENTER=${CASSANDRA_DATACENTER}
+        - CASSANDRA_RACK=${CASSANDRA_RACK}
+      hostname: laradock-cassandra
+      volumes:
+        - ${DATA_PATH_HOST}/cassandra:/var/lib/cassandra
       depends_on:
         - php-fpm
       networks:

--- a/env-example
+++ b/env-example
@@ -106,6 +106,7 @@ WORKSPACE_INSTALL_XSL=false
 WORKSPACE_INSTALL_IMAP=false
 WORKSPACE_INSTALL_MONGO=false
 WORKSPACE_INSTALL_AMQP=false
+WORKSPACE_INSTALL_CASSANDRA=false
 WORKSPACE_INSTALL_MSSQL=false
 WORKSPACE_INSTALL_DRUSH=false
 WORKSPACE_DRUSH_VERSION=8.1.17
@@ -161,6 +162,7 @@ PHP_FPM_INSTALL_PHPDBG=false
 PHP_FPM_INSTALL_IMAP=false
 PHP_FPM_INSTALL_MONGO=false
 PHP_FPM_INSTALL_AMQP=false
+PHP_FPM_INSTALL_CASSANDRA=false
 PHP_FPM_INSTALL_MSSQL=false
 PHP_FPM_INSTALL_SSH2=false
 PHP_FPM_INSTALL_SOAP=false
@@ -205,6 +207,7 @@ PHP_WORKER_INSTALL_SWOOLE=false
 PHP_WORKER_INSTALL_TAINT=false
 PHP_WORKER_INSTALL_FFMPEG=false
 PHP_WORKER_INSTALL_GMP=false
+PHP_WORKER_INSTALL_CASSANDRA=false
 
 PHP_WORKER_PUID=1000
 PHP_WORKER_PGID=1000
@@ -731,3 +734,36 @@ SONARQUBE_POSTGRES_HOST=postgres
 SONARQUBE_POSTGRES_DB=sonar
 SONARQUBE_POSTGRES_USER=sonar
 SONARQUBE_POSTGRES_PASSWORD=sonarPass
+
+### CASSANDRA ################################################
+
+# Cassandra Version, supported tags can be found at https://hub.docker.com/r/bitnami/cassandra/
+CASSANDRA_VERSION=latest
+# Inter-node cluster communication port. Default: 7000
+CASSANDRA_TRANSPORT_PORT_NUMBER=7000
+# JMX connections port. Default: 7199
+CASSANDRA_JMX_PORT_NUMBER=7199
+# Client port. Default: 9042.
+CASSANDRA_CQL_PORT_NUMBER=9042
+# Cassandra user name. Defaults: cassandra
+CASSANDRA_USER=cassandra
+# Password seeder will change the Cassandra default credentials at initialization. In clusters, only one node should be marked as password seeder. Default: no
+CASSANDRA_PASSWORD_SEEDER=no
+# Cassandra user password. Default: cassandra
+CASSANDRA_PASSWORD=cassandra
+# Number of tokens for the node. Default: 256.
+CASSANDRA_NUM_TOKENS=256
+# Hostname used to configure Cassandra. It can be either an IP or a domain. If left empty, it will be resolved to the machine IP.
+CASSANDRA_HOST=
+# Cluster name to configure Cassandra.. Defaults: My Cluster
+CASSANDRA_CLUSTER_NAME="My Cluster"
+# : Hosts that will act as Cassandra seeds. No defaults.
+CASSANDRA_SEEDS=
+ # Snitch name (which determines which data centers and racks nodes belong to). Default SimpleSnitch
+CASSANDRA_ENDPOINT_SNITCH=SimpleSnitch
+ # Enable the thrift RPC endpoint. Default :true
+CASSANDRA_ENABLE_RPC=true
+# Datacenter name for the cluster. Ignored in SimpleSnitch endpoint snitch. Default: dc1.
+CASSANDRA_DATACENTER=dc1
+# Rack name for the cluster. Ignored in SimpleSnitch endpoint snitch. Default: rack1.
+CASSANDRA_RACK=rack1

--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -45,6 +45,28 @@ RUN if [ ${INSTALL_PGSQL} = true ]; then \
   && docker-php-ext-install pdo_pgsql \
   ;fi
 
+# Install Cassandra drivers:
+ARG INSTALL_CASSANDRA=false
+RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
+  apk --update add cassandra-cpp-driver \
+  ;fi
+
+WORKDIR /usr/src
+RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
+  git clone https://github.com/datastax/php-driver.git \
+  && cd php-driver/ext \
+  && phpize \
+  && mkdir -p /usr/src/php-driver/build \
+  && cd /usr/src/php-driver/build \
+  && ../ext/configure > /dev/null \
+  && make clean >/dev/null \
+  && make >/dev/null 2>&1 \
+  && make install \
+  && docker-php-ext-enable cassandra \
+;fi
+
+
+
 ###########################################################################
 # PHP Memcached:
 ###########################################################################

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -85,6 +85,26 @@ RUN if [ ${INSTALL_AMQP} = true ]; then \
     docker-php-ext-install sockets \
 ;fi
 
+# Install Cassandra drivers:
+ARG INSTALL_CASSANDRA=false
+RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
+  apk --update add cassandra-cpp-driver \
+  ;fi
+
+WORKDIR /usr/src
+RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
+  git clone https://github.com/datastax/php-driver.git \
+  && cd php-driver/ext \
+  && phpize \
+  && mkdir -p /usr/src/php-driver/build \
+  && cd /usr/src/php-driver/build \
+  && ../ext/configure --with-php-config=/usr/bin/php-config7.1 > /dev/null \
+  && make clean >/dev/null \
+  && make >/dev/null 2>&1 \
+  && make install \
+  && docker-php-ext-enable cassandra \
+;fi
+
 # Install Phalcon ext
 ARG INSTALL_PHALCON=false
 ARG PHALCON_VERSION

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -407,6 +407,37 @@ RUN if [ ${INSTALL_AMQP} = true ]; then \
 ;fi
 
 ###########################################################################
+# CASSANDRA:
+###########################################################################
+
+ARG INSTALL_CASSANDRA=false
+
+RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
+    apt-get install libgmp-dev -y && \
+    curl https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.28.0/libuv1-dev_1.28.0-1_amd64.deb -o libuv1-dev.deb && \
+    curl https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.28.0/libuv1_1.28.0-1_amd64.deb -o libuv1.deb && \
+    curl https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.12.0/cassandra-cpp-driver-dev_2.12.0-1_amd64.deb -o cassandra-cpp-driver-dev.deb && \
+    curl https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.12.0/cassandra-cpp-driver_2.12.0-1_amd64.deb -o cassandra-cpp-driver.deb && \
+    dpkg -i libuv1.deb && \
+    dpkg -i libuv1-dev.deb && \
+    dpkg -i cassandra-cpp-driver.deb && \
+    dpkg -i cassandra-cpp-driver-dev.deb && \
+    rm libuv1.deb libuv1-dev.deb cassandra-cpp-driver-dev.deb cassandra-cpp-driver.deb && \
+    cd /usr/src && \
+    git clone https://github.com/datastax/php-driver.git && \
+    cd /usr/src/php-driver/ext && \
+    phpize && \
+    mkdir /usr/src/php-driver/build && \
+    cd /usr/src/php-driver/build && \
+    ../ext/configure > /dev/null && \
+    make clean >/dev/null && \
+    make >/dev/null 2>&1 && \
+    make install && \
+    echo "extension=cassandra.so" >> /etc/php/${LARADOCK_PHP_VERSION}/mods-available/cassandra.ini && \
+    ln -s /etc/php/${LARADOCK_PHP_VERSION}/mods-available/cassandra.ini /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/30-cassandra.ini \
+;fi
+
+###########################################################################
 # PHP REDIS EXTENSION
 ###########################################################################
 


### PR DESCRIPTION
<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)

This PR implements the feature of having the cassandra database system and also the PHP driver. 
Find the updated .env Variables:

```
WORKSPACE_INSTALL_CASSANDRA=false
PHP_FPM_INSTALL_CASSANDRA=false
PHP_WORKER_INSTALL_CASSANDRA=false
CASSANDRA_VERSION=latest
CASSANDRA_TRANSPORT_PORT_NUMBER=7000
CASSANDRA_JMX_PORT_NUMBER=7199
CASSANDRA_CQL_PORT_NUMBER=9042
CASSANDRA_USER=cassandra
CASSANDRA_PASSWORD_SEEDER=no
CASSANDRA_PASSWORD=cassandra
CASSANDRA_NUM_TOKENS=256
CASSANDRA_HOST=
CASSANDRA_CLUSTER_NAME="My Cluster"
CASSANDRA_SEEDS=
CASSANDRA_ENDPOINT_SNITCH=SimpleSnitch
CASSANDRA_ENABLE_RPC=true
CASSANDRA_DATACENTER=dc1
CASSANDRA_RACK=rack1
```

I chose to use the [Bitnami Image](https://hub.docker.com/r/bitnami/cassandra/) instead of the [official image](https://hub.docker.com/_/cassandra), because you can easily set a default user & password.

I hope everything is fine and i didn't forget anything. I also found in correlation with other DB Engines (RethinkDB, CouchDB, etc.) that there are no explicit guides to how install them in the documentation. So, FYI, to use cassandra just use `docker-compose up -d cassandra`.