### PR TITLE
Use the original base images after tagging PHP 7.3

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -250,7 +250,6 @@ docker-compose build php-fpm
 <br>
 <a name="Change-the-PHP-CLI-Version"></a>
 ## Change the PHP-CLI Version
-By default **PHP-CLI 7.0** is running.
 
 >Note: it's not very essential to edit the PHP-CLI version. The PHP-CLI is only used for the Artisan Commands & Composer. It doesn't serve your Application code, this is the PHP-FPM job.
 

--- a/env-example
+++ b/env-example
@@ -38,7 +38,7 @@ COMPOSE_PROJECT_NAME=laradock
 ### PHP Version ###########################################
 
 # Select a PHP version of the Workspace and PHP-FPM containers (Does not apply to HHVM). Accepted values: 7.3 - 7.2 - 7.1 - 7.0 - 5.6
-PHP_VERSION=7.2
+PHP_VERSION=7.3
 
 ### Phalcon Version ###########################################
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -14,8 +14,7 @@
 
 ARG LARADOCK_PHP_VERSION
 
-# FROM laradock/php-fpm:2.2-${LARADOCK_PHP_VERSION}
-FROM letsdockerize/laradock-php-fpm:2.4.1-${LARADOCK_PHP_VERSION}
+FROM laradock/php-fpm:2.5-${LARADOCK_PHP_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -14,8 +14,7 @@
 
 ARG LARADOCK_PHP_VERSION
 
-# FROM laradock/workspace:2.2-${LARADOCK_PHP_VERSION}
-FROM letsdockerize/laradock-workspace:2.4-${LARADOCK_PHP_VERSION}
+FROM laradock/workspace:2.5-${LARADOCK_PHP_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 


### PR DESCRIPTION
Replace the letsdockerize base images with the original once after creating tags for the images.

Closing https://github.com/laradock/workspace/issues/26 & https://github.com/laradock/php-fpm/issues/27

@bestlong Hi man, excuse my delay on that one. It's a nice solution you made. I created a new team in docker hub, should give you "and anyone interested" permissions to trigger those builds and make tags whenever needed (until automated). Could you please test my changes with at least 1 PHP version on your machine before merging it. And of course feel free to move any changes you made on the letsdockerize in here. Best,

@enomotodev @sonnygauran @panakour