### PR TITLE
Updata Caddyfile

### DIFF
--- a/caddy/caddy/Caddyfile
+++ b/caddy/caddy/Caddyfile
@@ -12,7 +12,7 @@
         to {path} {path}/ /index.php?{query}
     }
     gzip
-    browse
+    #browse
     log /var/log/caddy/access.log
     errors /var/log/caddy/error.log
     # Uncomment to enable TLS (HTTPS)


### PR DESCRIPTION
> browse enables directory browsing within the specified base path. It displays a file listing for directories which don't have an index file in them. In other server software, this is often called indexing.

> By default, file listings are disabled and a request to a directory path (where no index file is present) will result in a 404 for obscurity reasons.

I think broswer option may cause leak of the structure of files tree, so it's better disable it.

reference: https://caddyserver.com/docs/browse

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
