### PR TITLE
Laravel-Horizon - In Laravel 6.0 'PhpRedis' is now default instead of 'predis'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,6 +253,7 @@ services:
           - INSTALL_MEMCACHED=${PHP_FPM_INSTALL_MEMCACHED}
           - INSTALL_SOCKETS=${LARAVEL_HORIZON_INSTALL_SOCKETS}
           - INSTALL_CASSANDRA=${PHP_FPM_INSTALL_CASSANDRA}
+          - INSTALL_PHPREDIS=${LARAVEL_HORIZON_INSTALL_PHPREDIS}
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}
         - ./laravel-horizon/supervisord.d:/etc/supervisord.d

--- a/env-example
+++ b/env-example
@@ -225,6 +225,7 @@ NGINX_SSL_PATH=./nginx/ssl/
 ### LARAVEL_HORIZON ################################################
 
 LARAVEL_HORIZON_INSTALL_SOCKETS=false
+LARAVEL_HORIZON_INSTALL_PHPREDIS=true
 
 ### APACHE ################################################
 

--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -50,6 +50,15 @@ ARG INSTALL_CASSANDRA=false
 RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
   apk --update add cassandra-cpp-driver \
   ;fi
+  
+# Install PhpRedis
+ARG INSTALL_PHPREDIS=false
+RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
+    # Install Php Redis Extension
+    printf "\n" | pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis \
+;fi
 
 WORKDIR /usr/src
 RUN if [ ${INSTALL_CASSANDRA} = true ]; then \

--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -51,7 +51,7 @@ RUN if [ ${INSTALL_CASSANDRA} = true ]; then \
   apk --update add cassandra-cpp-driver \
   ;fi
   
-# Install PhpRedis
+# Install PhpRedis package:
 ARG INSTALL_PHPREDIS=false
 RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
     # Install Php Redis Extension


### PR DESCRIPTION
Laravel 6.0 uses PhpRedis as default driver (instead of 'predis/predis'); it should be installed into laravel-horizon image.

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
