### PR TITLE
MySql config file permissions fix

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -13,6 +13,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
 
 COPY my.cnf /etc/mysql/conf.d/my.cnf
 
+RUN chmod 0444 /etc/mysql/conf.d/my.cnf
+
 CMD ["mysqld"]
 
 EXPOSE 3306


### PR DESCRIPTION
Reason: [Warning] World-writable config file '/etc/mysql/docker-default.d/my.cnf' is ignored

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
