### PR TITLE
Add sample configuration for Visual Studio Code Remote Development

### DIFF
--- a/.devcontainer/devcontainer.example.json
+++ b/.devcontainer/devcontainer.example.json
@@ -1,0 +1,9 @@
+{
+  "name": "Laradock",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "runServices": ["nginx", "postgres", "pgadmin"],
+  "service": "workspace",
+  "workspaceFolder": "/var/www",
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "uname -a"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@
 /nginx/ssl/*.key
 /nginx/ssl/*.csr
 
+/.devcontainer/*
+!/.devcontainer/devcontainer.example.json
+
 .DS_Store

--- a/DOCUMENTATION/content/guides/index.md
+++ b/DOCUMENTATION/content/guides/index.md
@@ -70,6 +70,16 @@ If you want to only execute some command and don't want to enter bash, you can e
 docker-compose run workspace php artisan migrate
 ```
 
+### Prepare for Visual Studio Code remote development
+
+If you want to use Visual Studio Code for [remote development](https://code.visualstudio.com/docs/remote/containers) directly on your `workspace` container, copy file `devcontainer.example.json` to `devcontainer.json` and customize it (see [devcontainer.json reference](https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference) for more options):
+```
+cd .devcontainer
+cp devcontainer.example.json devcontainer.json
+```
+
+Then open your `laradock` folder in Visual Studio Code and click on popup button **Reopen in Container**.
+
 ### Install and configure Laravel
 
 Let's install Laravel's dependencies, add the `.env` file, generate the key and give proper permissions to the cache folder.


### PR DESCRIPTION
Add sample configuration for [Visual Studio Code Remote Development on Containers](https://code.visualstudio.com/docs/remote/containers). Just go to `.devcontainer` folder, copy file `devcontainer.example.json` to `devcontainer.json` and customize it (see [devcontainer.json reference](https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference) for more options).

This PR should be updated after issue https://github.com/microsoft/vscode-remote-release/issues/538 is closed.

Closes #2248

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
