### PR TITLE
Fixed 'mysql-client' has no installation candidate

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -708,7 +708,7 @@ ARG INSTALL_MYSQL_CLIENT=false
 
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
     apt-get update -yqq && \
-    apt-get -y install mysql-client \
+    apt-get -y install default-mysql-client \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
Fixed an issue that prevented php-fpm service from building successfully.
E: Package 'mysql-client' has no installation candidate

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [ *] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ *] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [ *] I enjoyed my time contributing and making developer's life easier :)
