### PR TITLE
Tag images with versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
 
 ### Workspace Utilities ##################################
     workspace:
+      image: workspace:${PHP_VERSION}
       build:
         context: ./workspace
         args:
@@ -144,6 +145,7 @@ services:
 
 ### PHP-FPM ##############################################
     php-fpm:
+      image: php-fpm:${PHP_VERSION}
       build:
         context: ./php-fpm
         args:
@@ -219,6 +221,7 @@ services:
 
 ### PHP Worker ############################################
     php-worker:
+      image: php-worker:${PHP_VERSION}
       build:
         context: ./php-worker
         args:
@@ -360,6 +363,7 @@ services:
 
 ### MySQL ################################################
     mysql:
+      image: mysql:${MYSQL_VERSION}
       build:
         context: ./mysql
         args:
@@ -412,6 +416,7 @@ services:
 
 ### MariaDB ##############################################
     mariadb:
+      image: mariadb:${MARIADB_VERSION}
       build:
         context: ./mariadb
         args:


### PR DESCRIPTION
I suggest tagging the built images by default.

Affected containers:
- workspace
- php-fpm
- php-worker
- mysql
- mariadb

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
