### PR TITLE
Install default-mysql-client for PHP 7.3

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -707,8 +707,13 @@ USER root
 ARG INSTALL_MYSQL_CLIENT=false
 
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
-    apt-get update -yqq && \
-    apt-get -y install mysql-client \
+    if [ ${LARADOCK_PHP_VERSION} = "7.3" ]; then \
+      apt-get update -yqq && \
+      apt-get -y install default-mysql-client \
+    ;else \
+      apt-get update -yqq && \
+      apt-get -y install mysql-client \
+    ;fi \
 ;fi
 
 ###########################################################################

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -707,11 +707,10 @@ USER root
 ARG INSTALL_MYSQL_CLIENT=false
 
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
+    apt-get update -yqq && \
     if [ ${LARADOCK_PHP_VERSION} = "7.3" ]; then \
-      apt-get update -yqq && \
       apt-get -y install default-mysql-client \
     ;else \
-      apt-get update -yqq && \
       apt-get -y install mysql-client \
     ;fi \
 ;fi

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -66,7 +66,11 @@ RUN if [ ${INSTALL_ZIP_ARCHIVE} = true ]; then \
 # Install MySQL Client:
 ARG INSTALL_MYSQL_CLIENT=false
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
-    apk --update add mysql-client \
+    if [ ${PHP_VERSION} = "7.3" ]; then \
+      apk --update add default-mysql-client \
+    ;else \
+      apk --update add mysql-client \
+    ;fi \
 ;fi
 
 # Install FFMPEG:


### PR DESCRIPTION
> php:7.3-fpm now use Debian 10 (Buster) as its base image and Buster ships with MariaDB. (https://stackoverflow.com/a/57049357/1478344)

`default-mysql-client` should be used for `php-fpm` and `php-worker` containers. The `workspace` container is not affected.

`mariadb-client` is also available, maybe this should be another environment variable.

This pull request fixes the same issue as #2321 and #2306, adding a check for the PHP version. It only applies to PHP 7.3. This will have to be revised for 7.4 and future releases.

Related issues: #2257

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
