### PR TITLE
Fix localhost address

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -221,8 +221,12 @@ Or you can change them and rebuild the container.
 <br>
 5 - Open your browser and visit your localhost address. 
 
+Make sure you add use the right port number as provided by your running server.
+
+[http://localhost:80](http://localhost:80)
+
 If you followed the multiple projects setup, you can visit `http://project-1.test/` and `http://project-2.test/`.
 
-[http://localhost:8080](http://localhost:8080)
 
-Make sure you add use the right port number as provided by your running server. Ex: NGINX uses port 8080 by default while Apache2 uses 80.   
+
+ 

--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -223,7 +223,7 @@ Or you can change them and rebuild the container.
 
 Make sure you add use the right port number as provided by your running server.
 
-[http://localhost:80](http://localhost:80)
+[http://localhost](http://localhost)
 
 If you followed the multiple projects setup, you can visit `http://project-1.test/` and `http://project-2.test/`.
 


### PR DESCRIPTION
Nginx also uses port 80 by default.

https://github.com/laradock/laradock/blob/04c6aaf3389ebd30e2874788b90437f229effb0b/nginx/Dockerfile#L42

---

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
