### PR TITLE
Update to Kibana 7.1.1

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana:6.6.0
+FROM docker.elastic.co/kibana/kibana:7.1.1
 
 EXPOSE 5601


### PR DESCRIPTION
When spinning up the stack via `docker-compose -d apache2 elasticsearch kibana` Kibana won't work currently and displays "kibana is not ready yet". `docker-compose logs kibana` the message:

```
{"type":"log","@timestamp":"2019-11-14T15:46:37Z","tags":["status","plugin:reporting@6.6.0","error"],"pid":1,"state":"red","message":"Status changed from uninitialized to red - This version of Kibana requires Elasticsearch v6.6.0 on all nodes. I found the following incompatible nodes in your cluster: v7.1.1 @ 172.26.0.3:9200 (172.26.0.3)","prevState":"uninitialized","prevMsg":"uninitialized"}
```

I update the version to align with elasticsearchs' version which works fine on my machine.

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [ ] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [ ] I enjoyed my time contributing and making developer's life easier :)
