### PR TITLE
fix 404 not found with nginx

### DIFF
--- a/nginx/sites/laravel.conf.example
+++ b/nginx/sites/laravel.conf.example
@@ -10,7 +10,7 @@ server {
     # ssl_certificate_key /etc/nginx/ssl/default.key;
 
     server_name laravel.test;
-    root /var/www/laravel/public;
+    root /var/www/public;
     index index.php index.html index.htm;
 
     location / {


### PR DESCRIPTION
fix #1589 and ref #86

## Project Folder Structure

```
├── laradock
└── www
```

Please make sure that `public` folder of Laravel project in `www`

## Modified `laradock/.env`

```yml
APP_CODE_PATH_HOST=../www
```

## Copy nginx config

```sh
cp -r nginx/sites/laravel.conf.example nginx/sites/laravel.test.conf
```

Add `laravle.test` in `/etc/hosts`

```
127.0.0.1 laravel.test
```

## open your browser

open http://laravel.test or you can change the hostname to http://localhost
