### PR TITLE
Complete sample configuration for VSCode Remote Development on Containers

### DIFF
--- a/.devcontainer/devcontainer.example.json
+++ b/.devcontainer/devcontainer.example.json
@@ -1,7 +1,15 @@
 {
   "name": "Laradock",
-  "dockerComposeFile": ["../docker-compose.yml"],
-  "runServices": ["nginx", "postgres", "pgadmin"],
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.extend.yml"
+  ],
+  "remoteUser": "laradock",
+  "runServices": [
+    "nginx",
+    "postgres",
+    "pgadmin"
+  ],
   "service": "workspace",
   "workspaceFolder": "/var/www",
   "shutdownAction": "stopCompose",

--- a/.devcontainer/docker-compose.extend-example.yml
+++ b/.devcontainer/docker-compose.extend-example.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  workspace:
+    volumes:
+      - ~/.gitconfig:/home/laradock/.gitconfig
+      - ~/.ssh:/home/laradock/.ssh:ro

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 
 /.devcontainer/*
 !/.devcontainer/devcontainer.example.json
+!/.devcontainer/docker-compose.extend-example.yml
 
 .DS_Store


### PR DESCRIPTION
This PR just fills up the remaining gaps of the previous one (https://github.com/laradock/laradock/pull/2319) now that `devcontainer.json` option `remoteUser`, which closes https://github.com/microsoft/vscode-remote-release/issues/538, is finally available.

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
