### PR TITLE
Drop unneeded settings for devcontainer.json (VSCode already handles them automatically)

### DIFF
--- a/.devcontainer/devcontainer.example.json
+++ b/.devcontainer/devcontainer.example.json
@@ -1,9 +1,6 @@
 {
   "name": "Laradock",
-  "dockerComposeFile": [
-    "../docker-compose.yml",
-    "docker-compose.extend.yml"
-  ],
+  "dockerComposeFile": "../docker-compose.yml",
   "remoteUser": "laradock",
   "runServices": [
     "nginx",

--- a/.devcontainer/docker-compose.extend-example.yml
+++ b/.devcontainer/docker-compose.extend-example.yml
@@ -1,6 +1,0 @@
-version: '3'
-services:
-  workspace:
-    volumes:
-      - ~/.gitconfig:/home/laradock/.gitconfig
-      - ~/.ssh:/home/laradock/.ssh:ro


### PR DESCRIPTION
This fixes some mistakes in previous PR https://github.com/laradock/laradock/pull/2413. There's no need for manual configuration regarding user's `.gitconfig` and/or SSH agent sharing with the workspace container, because Visual Studio Code 1.41 will handle them automatically.

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
