### PR TITLE
Fix grafana init error

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,3 +1,7 @@
 FROM grafana/grafana:latest
-
+USER root
+RUN chown -R root:root /etc/grafana
+RUN chmod -R a+r /etc/grafana
+RUN chown -R grafana:grafana /var/lib/grafana
+RUN chown -R grafana:grafana /usr/share/grafana
 EXPOSE 3000


### PR DESCRIPTION
See bug report: https://github.com/laradock/laradock/issues/1783

grafana_1              | GF_PATHS_DATA='/var/lib/grafana' is not writable.
grafana_1              | You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later
grafana_1              | mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
laradock_grafana_1 exited with code 1
