### PR TITLE
Improvements on ELK Stack images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -770,7 +770,10 @@ services:
 
 ### ElasticSearch ########################################
     elasticsearch:
-      build: ./elasticsearch
+      build:
+        context: ./elasticsearch
+        args:
+          - ELK_VERSION=${ELK_VERSION}
       volumes:
         - elasticsearch:/usr/share/elasticsearch/data
       environment:
@@ -794,7 +797,10 @@ services:
 
 ### Logstash ##############################################
     logstash:
-      build: ./logstash
+      build:
+        context: ./logstash
+        args:
+          - ELK_VERSION=${ELK_VERSION}
       volumes:
         - './logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml'
         - './logstash/pipeline:/usr/share/logstash/pipeline'
@@ -812,7 +818,10 @@ services:
 
 ### Kibana ##############################################
     kibana:
-      build: ./kibana
+      build:
+        context: ./kibana
+        args:
+          - ELK_VERSION=${ELK_VERSION}
       ports:
         - "${KIBANA_HTTP_PORT}:5601"
       depends_on:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+ARG ELK_VERSION=7.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
 
 EXPOSE 9200 9300

--- a/env-example
+++ b/env-example
@@ -848,3 +848,6 @@ GEARMAN_MYSQL_PASSWORD_FILE=
 GEARMAN_MYSQL_DB=Gearmand
 # Table to use by Gearman (Default: gearman_queue)
 GEARMAN_MYSQL_TABLE=gearman_queue
+
+### ELK Stack ##################################################
+ELK_VERSION=7.5.1

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,4 @@
-FROM docker.elastic.co/kibana/kibana:7.1.1
+ARG ELK_VERSION=7.5.1
+FROM docker.elastic.co/kibana/kibana:${ELK_VERSION}
 
 EXPOSE 5601

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.elastic.co/logstash/logstash:6.4.2
+ARG ELK_VERSION=7.5.1
+FROM docker.elastic.co/logstash/logstash:${ELK_VERSION}
 
 USER root
 RUN rm -f /usr/share/logstash/pipeline/logstash.conf


### PR DESCRIPTION
This change is only intended to minimize errors when the developer wants to use containers based on images of the ELK Stack (Elasticsearch, logstash and kibana). As recommended on the documentation, when using these softwares togheter its mandatory to use them with the same version. I created an environment variable on env.example to centralize the input of the version number, so each Dockerfile can reference it on the build process.

Reference: https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
