### PR TITLE
XDebug - Default to host.docker.internal

### DIFF
--- a/php-fpm/xdebug.ini
+++ b/php-fpm/xdebug.ini
@@ -1,7 +1,7 @@
 ; NOTE: The actual debug.so extention is NOT SET HERE but rather (/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini)
 
-; xdebug.remote_host=dockerhost
-xdebug.remote_connect_back=1
+xdebug.remote_host="host.docker.internal"
+xdebug.remote_connect_back=0
 xdebug.remote_port=9000
 xdebug.idekey=PHPSTORM
 
@@ -17,4 +17,3 @@ xdebug.remote_mode=req
 xdebug.var_display_max_children=-1
 xdebug.var_display_max_data=-1
 xdebug.var_display_max_depth=-1
-

--- a/workspace/xdebug.ini
+++ b/workspace/xdebug.ini
@@ -1,7 +1,7 @@
 ; NOTE: The actual debug.so extention is NOT SET HERE but rather (/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini)
 
-; xdebug.remote_host=dockerhost
-xdebug.remote_connect_back=1
+xdebug.remote_host="host.docker.internal"
+xdebug.remote_connect_back=0
 xdebug.remote_port=9000
 xdebug.idekey=PHPSTORM
 
@@ -17,4 +17,3 @@ xdebug.remote_mode=req
 xdebug.var_display_max_children=-1
 xdebug.var_display_max_data=-1
 xdebug.var_display_max_depth=-1
-


### PR DESCRIPTION
## Description
Change te default configuration for xdebug to use the remote host and the special DNS variable that Docker defines for Docker for Mac and Docker for Windows.

<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
Myself and many others before me have been struggling with the current default configuration for PHP XDebug. Apart from the fact that `xdebug.remote_connect_back=1` simply doesn't work for the majority of people (for reasons currently still beyond me), the recommended approach is in fact to use `xdebug.remote_host` and Docker's special DNS for the host `host.docker.internal`.

While trying to get xdebug to work, I also got the impression that this is the way most people configure things to get a xdebug connection up and running again.

Two questions to people more experienced with this than I am:

1. The Docker docs state that: ` This (the magic DNS variable) is for development purpose and will not work in a production environment outside of Docker Desktop for Windows`. How should this be setup for a production environment IF that even makes sense considering the security implications of enabling a debugger in production.

2. How to fix for users with a Linux box? Perhaps we should install/use different `xdebug.ini` files depending on the platform and environment? What are your thoughts on this?

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
