### PR TITLE
Fix: Use native MySQL password as default auth

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,3 +8,4 @@
 [mysqld]
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
+default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
## Description
Fixes connection refused error when using latest MySQL version - described here: 
https://github.com/laradock/laradock/issues/1752
https://github.com/laradock/laradock/issues/2105

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
