### PR TITLE
Fix: Mysql-client has no installation candidate

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -810,11 +810,7 @@ USER root
 ARG INSTALL_MYSQL_CLIENT=false
 
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
-    if [ ${LARADOCK_PHP_VERSION} = "7.3" ]; then \
       apt-get -y install default-mysql-client \
-    ;else \
-      apt-get -y install mysql-client \
-    ;fi \
 ;fi
 
 ###########################################################################

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -96,11 +96,7 @@ RUN set -eux; \
 # Install MySQL Client:
 ARG INSTALL_MYSQL_CLIENT=false
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
-    if [ ${LARADOCK_PHP_VERSION} = "7.3" ]; then \
       apk --update add default-mysql-client \
-    ;else \
-      apk --update add mysql-client \
-    ;fi \
 ;fi
 
 # Install FFMPEG:

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
 # Install MySQL Client:
 ARG INSTALL_MYSQL_CLIENT=false
 RUN if [ ${INSTALL_MYSQL_CLIENT} = true ]; then \
-      apk --update add default-mysql-client \
+      apk --update add mysql-client \
 ;fi
 
 # Install FFMPEG:


### PR DESCRIPTION
## Description
Fixes https://github.com/laradock/laradock/issues/2257
Tested on PHP version 5.6, 7.0, 7.1, 7.2, 7.4. 

As same code is in php-worker and php-fpm I fixed php-worker Dockerfile too.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
