### PR TITLE
fix(php-fpm): Add graphviz if xhprof is installed

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -340,6 +340,7 @@ RUN if [ ${INSTALL_XHPROF} = true ]; then \
     ) \
     && rm -r xhprof \
     && rm /tmp/xhprof.tar.gz \
+    && apt-get install -y graphviz \
 ;fi
 
 COPY ./xhprof.ini /usr/local/etc/php/conf.d


### PR DESCRIPTION
## Description
Xhprof extension requires `graphviz` for draw graph. Current changes make it installed only when `xhprof` is built.

## Motivation and Context
Currently after `php-fpm` image is built with `xhprof`, we should install `graphviz` manually. I think it would be great to get it done in automatic way.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
