### PR TITLE
Add ElasticSearch plugin command alternative

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -1209,6 +1209,12 @@ docker-compose up -d elasticsearch
 ```bash
 docker-compose exec elasticsearch /usr/share/elasticsearch/bin/plugin install {plugin-name}
 ```
+For ElasticSearch 5.0 and above, the previous "plugin" command as been renamed to "elasticsearch-plguin". 
+Use the following instead:
+
+```bash
+docker-compose exec elasticsearch /usr/share/elasticsearch/bin/elasticsearch-plugin install {plugin-name}
+```
 
 2 - Restart elasticsearch container
 


### PR DESCRIPTION
## Description
It seems that since ES 5.0, the "plugin" script is now named "elasticseach-plugin".
Using the provided command would result in a :
"/usr/share/elasticsearch/bin/plugin no such file or directory"

This PR adds this information to the DOCUMENTATION and provides the alternative command to install a new plugin.

## Motivation and Context
I encountered the error while setting up my own installation with Laradock. I thought it would save some time to others following the documentation and setting up ES plugins.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Adding documentation details

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)

Thanks for creating and maintaining Laradock, it helped a lot in learning Docker.
