### PR TITLE
Fix Deployer documentation link

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -395,7 +395,7 @@ Always download the latest version of [Loaders for ionCube ](http://www.ioncube.
 
 4 - Re-build the containers `docker-compose build workspace`
 
-[**Deployer Documentation Here**](https://deployer.org/docs)
+[**Deployer Documentation Here**](https://deployer.org/docs/getting-started.html)
 
 
 


### PR DESCRIPTION
## Description
The current deployer link (https://deployer.org/docs/) is getting 403, It's just update the link to a working link



