### PR TITLE
Installing Filebeat plugin

### DIFF
--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -8,4 +8,5 @@ ADD ./pipeline/ /usr/share/logstash/pipeline/
 ADD ./config/ /usr/share/logstash/config/
 
 RUN logstash-plugin install logstash-input-jdbc
+RUN logstash-plugin install logstash-input-beats
 


### PR DESCRIPTION
Add support to Filebeat with logstash-input-beats plugin

## Description
This input plugin enables Logstash to receive events from the Elastic Beats framework 

## Motivation and Context
Add Filebeat support 
