### PR TITLE
fixed supervisor docker-composer instead of docker-compose syntax error

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -2067,7 +2067,7 @@ To install Supervisor in the Workspace container
 
 3 - Create supervisor configuration file (for ex., named `laravel-worker.conf`) for Laravel Queue Worker in `php-worker/supervisord.d/` by simply copy from `laravel-worker.conf.example`
 
-4 - Re-build the container `docker-compose build workspace` Or `docker-composer up --build -d workspace`
+4 - Re-build the container `docker-compose build workspace` Or `docker-compose up --build -d workspace`
 
 
 


### PR DESCRIPTION
## Description
Minor documentation  syntax error in the supervisor documentation **docker-composer instead of docker-compose**
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
Documentation problem
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
