### PR TITLE
fix of the default gearman port

### DIFF
--- a/env-example
+++ b/env-example
@@ -852,8 +852,8 @@ CASSANDRA_RACK=rack1
 
 # Gearman version to use. See available tags at https://hub.docker.com/r/artefactual/gearmand
 GEARMAN_VERSION=latest
-# Port to use (Default: 6379)
-GEARMAN_PORT=6379
+# Port to use (Default: 4730)
+GEARMAN_PORT=4730
 # Logging Level (Default: INFO)
 GEARMAN_VERBOSE=INFO
 # Persistent queue type to use (Default: builtin)


### PR DESCRIPTION
## Description
The default port used by GEARMAN is 4730. Currently the 6379 port used by REDIS is entered.

## Motivation and Context
When using REDIS and GEARMAN simultaneously, one of the containers does not start.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
