### PR TITLE
Makes easy login into mysql server

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -9,3 +9,7 @@
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
 default-authentication-plugin=mysql_native_password
+
+[client]
+user=root
+password="root"


### PR DESCRIPTION
Avoid pass user flag and password flag to mysql command into mysql container for log in mysql server that's running.

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
