### PR TITLE
Update Use AWS Docs

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -1366,7 +1366,7 @@ For more documentation on Thumbor visit the [Thumbor documenation](http://thumbo
 ## Use AWS
 
 1 - Configure AWS:
-  - make sure to add your SSH keys in aws/ssh_keys folder
+  - make sure to add your SSH keys in aws-eb-cli/ssh_keys folder
 
 2 - Run the Aws Container (`aws`) with the `docker-compose up` command. Example:
 


### PR DESCRIPTION
Update Use AWS Docs

## Motivation and Context
I flowed the docs to use AWS on Windows but it failed 
```
Step 6/8 : COPY /ssh_keys/. /root/.ssh/
ERROR: Service 'aws' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder893006516/ssh_keys: no such file or directory
```

but the real path is `aws-eb-cli/ssh_keys` not `aws/ssh_keys`
