### PR TITLE
Fix PHP-Worker GD "Unable to init from given binary data"

### DIFF
--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -56,7 +56,8 @@ RUN if [ ${INSTALL_BZ2} = true ]; then \
 #Install GD package:
 ARG INSTALL_GD=false
 RUN if [ ${INSTALL_GD} = true ]; then \
-   apk add --update --no-cache libpng-dev; \
+   apk add --update --no-cache freetype-dev libjpeg-turbo-dev jpeg-dev libpng-dev; \
+   docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/ && \
    docker-php-ext-install gd \
 ;fi
 

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -62,7 +62,8 @@ fi
 #Install GD package:
 ARG INSTALL_GD=false
 RUN if [ ${INSTALL_GD} = true ]; then \
-   apk add --update --no-cache libpng-dev; \
+   apk add --update --no-cache freetype-dev libjpeg-turbo-dev jpeg-dev libpng-dev; \
+   docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/ && \
    docker-php-ext-install gd \
 ;fi
 


### PR DESCRIPTION
## Description
This pr added freetype-dev libjpeg-turbo-dev jpeg-dev for GD to my branch.

When i use `Image::make($url);` i will got an error 
`Intervention\Image\Exception\NotReadableException: Unable to init from given binary data. in /var/www/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php:115`

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
