### PR TITLE
Workspace SQLSRV PHP7.1 Support

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1003,8 +1003,10 @@ RUN set -eux; \
       ln -sfn /opt/mssql-tools/bin/bcp /usr/bin/bcp && \
       echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
       locale-gen && \
-      if [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ]; then \
+      if [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70000" ]; then \
         pecl install sqlsrv-5.3.0 pdo_sqlsrv-5.3.0 \
+      ;elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70100" ]; then \
+        pecl install sqlsrv-5.6.1 pdo_sqlsrv-5.6.1 \
       ;else \
         pecl install sqlsrv pdo_sqlsrv \
       ;fi && \


### PR DESCRIPTION
## Description
-Updates INSTALL_MSSQL script to install SQLSRV5.6.1 on PHP7.1 since Microsoft dropped PHP7.1 support in SQLSRV5.8.
-Match with the PHP major and Minor version to avoid possible future conflict with major php release. ex: PHP8.0

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
