### PR TITLE
fix: use postgresql-client-12 in workspace

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1160,10 +1160,10 @@ ARG INSTALL_PG_CLIENT=false
 RUN if [ ${INSTALL_PG_CLIENT} = true ]; then \
     # Install the pgsql client
     apt-get install wget \
-    && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get -y install postgresql-client-10 \
+    && apt-get -y install postgresql-client-12 \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
## Description

I updated the PostgreSQL client version in `workspace` to be version 12. This should be a non-breaking change as it's still possible to import backups from earlier versions, but it wasn't possible to import newer backups using an older version of postgresql-client.

## Motivation and Context

In production we use PostgreSQL 12 as it's the newest PostgreSQL version, in laradock's workspace the PostgreSQL client version is 10, therefore it's not possible to import a binary database export from a newer PostgreSQL version (exported via pg_dump and the `-Fc` flags).

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
