### PR TITLE
Upgrade Caddy Webserver to version 2

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,5 +1,5 @@
-FROM abiosoft/caddy:no-stats
+FROM caddy/caddy:latest
 
-CMD ["--conf", "/etc/caddy/Caddyfile", "--log", "stdout", "--agree=true"]
+COPY ./caddy/Caddyfile /etc/caddy/Caddyfile
 
-EXPOSE 80 443 2015
+EXPOSE 80 443

--- a/caddy/caddy/Caddyfile
+++ b/caddy/caddy/Caddyfile
@@ -1,51 +1,9 @@
 # Docs: https://caddyserver.com/docs/caddyfile
-0.0.0.0:80 {
-    root /var/www/public
-    fastcgi / php-fpm:9000 php {
-        index index.php
-    }
+laradock.test {
+    root * /var/www/public
+    php_fastcgi php-fpm:9000
+    file_server
 
-    # To handle .html extensions with laravel change ext to
-    # ext / .html
-
-    rewrite {
-        to {path} {path}/ /index.php?{query}
-    }
-    gzip
-    browse
-    log /var/log/caddy/access.log
-    errors /var/log/caddy/error.log
-    # Uncomment to enable TLS (HTTPS)
-    # Change the first list to listen on port 443 when enabling TLS
-    #tls self_signed
-
-    # To use Lets encrpt tls with a DNS provider uncomment these
-    # lines and change the provider as required
-    #tls {
-    #  dns cloudflare
-    #}
-}
-
-laradock1.demo:80 {
-    root /var/www/public
-    # Create a Webhook in git.
-    #git {
-	#repo https://github.com/xxx/xxx
-    #    path /home/xxx
-    #    #interval 60
-    #    hook  webhook laradock
-    #    hook_type   generic
-    #}
-
-}
-
-laradock2.demo:80 {
-    # Create a Proxy and cors.
-    #proxy domain.com
-	#cors
-}
-
-laradock3.demo:80 {
-    import authlist.conf
-    root /var/www/public
+    encode gzip
+    tls internal
 }

--- a/caddy/caddy/authlist.conf
+++ b/caddy/caddy/authlist.conf
@@ -1,1 +1,0 @@
-basicauth / laradock laradock


### PR DESCRIPTION
## Description
Upgrade Caddy webserver to start using version 2

## Motivation and Context
Caddy V1 is no longer supported so moving to V2 should be encouraged.

## Types of Changes
- [] Updated the Dockerfile to use Caddy V2 from the official Docker Hub repository
- [] Update the Caddyfile to have just one local https served host as an example
- [] Removed the same authfile config. I have never used it.

## Definition of Done Checklist:
- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I enjoyed my time contributing and making developer's life easier :)
