### PR TITLE
Add aliases to .zshrc in workspace when SHELL_OH_MY_ZSH=true

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1413,6 +1413,36 @@ bindkey "^?" backward-delete-char\n' >> /home/laradock/.zshrc \
 
 USER root
 
+###########################################################################
+# ZSH User Aliases
+###########################################################################
+
+USER root
+
+COPY ./aliases.sh /root/aliases.sh
+COPY ./aliases.sh /home/laradock/aliases.sh
+
+RUN if [ ${SHELL_OH_MY_ZSH} = true ]; then \
+    sed -i 's/\r//' /root/aliases.sh && \
+    sed -i 's/\r//' /home/laradock/aliases.sh && \
+    chown laradock:laradock /home/laradock/aliases.sh && \
+    echo "" >> ~/.zshrc && \
+    echo "# Load Custom Aliases" >> ~/.zshrc && \
+    echo "source ~/aliases.sh" >> ~/.zshrc && \
+	  echo "" >> ~/.zshrc \
+;fi
+
+USER laradock
+
+RUN if [ ${SHELL_OH_MY_ZSH} = true ]; then \
+    echo "" >> ~/.zshrc && \
+    echo "# Load Custom Aliases" >> ~/.zshrc && \
+    echo "source ~/aliases.sh" >> ~/.zshrc && \
+	  echo "" >> ~/.zshrc \
+;fi
+
+USER root
+
 #
 #--------------------------------------------------------------------------
 # Final Touch


### PR DESCRIPTION
Updated Workspace Dockerfile to add aliases to .zshrc if SHELL_OH_MY_ZSH is set to "true".

## Description
This is a non-breaking change to the Workspace dockerfile. I added a section to link aliases.sh in the .zshrc for the root and laradock users, just like is being done for the .bashrc. I don't believe this needs a documentation change, but feel free to let me know if I am incorrect.
[Issue Here](https://github.com/laradock/laradock/issues/2703)

## Motivation and Context
I enjoy using ZSH, but I found the lack of common aliases that I had used in Bash to be frustrating. I made this change locally, and it worked well, so I decided to contribute back to the project.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
