### PR TITLE
Fix protoc bin & include permissions in workspace

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1404,7 +1404,9 @@ RUN if [ ${INSTALL_PROTOC} = true ]; then \
   curl -L -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${REAL_PROTOC_VERSION}/${PROTOC_ZIP} && \
   unzip -q -o /tmp/protoc.zip -d /usr/local bin/protoc && \
   unzip -q -o /tmp/protoc.zip -d /usr/local 'include/*' && \
-  rm -f /tmp/protoc.zip \
+  rm -f /tmp/protoc.zip && \
+  chmod +x /usr/local/bin/protoc && \
+  chmod -R +r /usr/local/include/google \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
## Description
Fix protoc bin & include permissions in workspace

## Motivation and Context
This will allow the laradock user to execute protoc commands

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
