### PR TITLE
Fix xdebug config .so path so that xdebug start/xdebug stop works

### DIFF
--- a/php-fpm/xdebug
+++ b/php-fpm/xdebug
@@ -36,7 +36,7 @@ xdebug_start ()
 
     # And uncomment line with xdebug extension, thus enabling it
     ON_CMD="sed -i 's/^;zend_extension=/zend_extension=/g' \
-                    /usr/local/etc/php/conf.d/xdebug.ini"
+                    /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
 
 
     # If running on Windows, need to prepend with winpty :(
@@ -58,7 +58,7 @@ xdebug_stop ()
     echo 'Stop xDebug'
 
     # Comment out xdebug extension line
-    OFF_CMD="sed -i 's/^zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/xdebug.ini"
+    OFF_CMD="sed -i 's/^zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
 
 
     # If running on Windows, need to prepend with winpty :(


### PR DESCRIPTION
## Description
Update the xdebug.ini pathing to correctly point to the docker php ext xdebug config instead of xdebug.ini since the .so file this command tries to comment out is stored under docker-php-ext-xdebug.ini and not xdebug.ini.

xdebug.ini
![image](https://user-images.githubusercontent.com/7674587/94088608-41a10100-fe54-11ea-82ed-91b9958f6026.png)
php-docker-ext-debug.ini
![image](https://user-images.githubusercontent.com/7674587/94088789-ae1c0000-fe54-11ea-95f4-4377c325eb23.png)

## Motivation and Context
Fixes the .php-fpm/xdebug stop and .php-fpm/xdebug start command not working

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I enjoyed my time contributing and making developer's life easier :)
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
