### PR TITLE
feat: Add support for custom Adminer plugins, designs and default servers

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -1077,6 +1077,14 @@ docker-compose up -d adminer
 
 2 - Open your browser and visit the localhost on port **8081**:  `http://localhost:8081`
 
+#### Additional Notes
+
+- You can load plugins in the `ADM_PLUGINS` variable in the `.env` file. If a plugin requires parameters to work correctly you will need to add a custom file to the container. [Find more info in section 'Loading plugins'](https://hub.docker.com/_/adminer).
+
+- You can choose a design in the `ADM_DESIGN` variable in the `.env` file. [Find more info in section 'Choosing a design'](https://hub.docker.com/_/adminer).
+
+- You can specify the default host with the `ADM_DEFAULT_SERVER` variable in the `.env` file. This is useful if you are connecting to an external server or a docker container named something other than the default `mysql`.
+
 **Note:** We've locked Adminer to version 4.3.0 as at the time of writing [it contained a major bug](https://sourceforge.net/p/adminer/bugs-and-features/548/) preventing PostgreSQL users from logging in. If that bug is fixed (or if you're not using PostgreSQL) feel free to set Adminer to the latest version within [the Dockerfile](https://github.com/laradock/laradock/blob/master/adminer/Dockerfile#L1): `FROM adminer:latest`
 
 

--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -874,14 +874,14 @@ run from any cli: <br>`curl -X PURGE https://yourwebsite.com/`.
 2. How to reload varnish?<br>
 `docker container exec proxy varnishreload`
 3. Which varnish commands are allowed?
-    - varnishadm     
-    - varnishd      
-    - varnishhist    
-    - varnishlog     
-    - varnishncsa    
-    - varnishreload  
-    - varnishstat    
-    - varnishtest    
+    - varnishadm
+    - varnishd
+    - varnishhist
+    - varnishlog
+    - varnishncsa
+    - varnishreload
+    - varnishstat
+    - varnishtest
     - varnishtop
 4. How to reload Nginx?<br>
 `docker exec Nginx nginx -t`<br>
@@ -1085,7 +1085,6 @@ docker-compose up -d adminer
 
 - You can specify the default host with the `ADM_DEFAULT_SERVER` variable in the `.env` file. This is useful if you are connecting to an external server or a docker container named something other than the default `mysql`.
 
-**Note:** We've locked Adminer to version 4.3.0 as at the time of writing [it contained a major bug](https://sourceforge.net/p/adminer/bugs-and-features/548/) preventing PostgreSQL users from logging in. If that bug is fixed (or if you're not using PostgreSQL) feel free to set Adminer to the latest version within [the Dockerfile](https://github.com/laradock/laradock/blob/master/adminer/Dockerfile#L1): `FROM adminer:latest`
 
 
 
@@ -1220,7 +1219,7 @@ docker-compose up -d elasticsearch
 ```bash
 docker-compose exec elasticsearch /usr/share/elasticsearch/bin/plugin install {plugin-name}
 ```
-For ElasticSearch 5.0 and above, the previous "plugin" command has been renamed to "elasticsearch-plguin". 
+For ElasticSearch 5.0 and above, the previous "plugin" command has been renamed to "elasticsearch-plguin".
 Use the following instead:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -814,7 +814,9 @@ services:
         args:
           - INSTALL_MSSQL=${ADM_INSTALL_MSSQL}
       environment:
+          - ADMINER_PLUGINS=${ADM_PLUGINS}
           - ADMINER_DESIGN=${ADM_DESIGN}
+          - ADMINER_DEFAULT_SERVER=${ADM_DEFAULT_SERVER}
       ports:
         - "${ADM_PORT}:8080"
       depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -813,6 +813,8 @@ services:
         context: ./adminer
         args:
           - INSTALL_MSSQL=${ADM_INSTALL_MSSQL}
+      environment:
+          - ADMINER_DESIGN=${ADM_DESIGN}
       ports:
         - "${ADM_PORT}:8080"
       depends_on:

--- a/env-example
+++ b/env-example
@@ -428,6 +428,7 @@ MINIO_PORT=9000
 
 ADM_PORT=8081
 ADM_INSTALL_MSSQL=false
+ADM_DESIGN=pepa-linha
 
 ### PHP MY ADMIN ##########################################
 

--- a/env-example
+++ b/env-example
@@ -428,7 +428,9 @@ MINIO_PORT=9000
 
 ADM_PORT=8081
 ADM_INSTALL_MSSQL=false
+ADM_PLUGINS=
 ADM_DESIGN=pepa-linha
+ADM_DEFAULT_SERVER=mysql
 
 ### PHP MY ADMIN ##########################################
 


### PR DESCRIPTION
## Description
Add support for custom Adminer plugins, designs and default servers.

## Motivation and Context
- Users can load Adminer plugins.
- Users can choose a design from the source package of Adminer.
- Users can specify the default host for Adminer.
- Remove the outdated note in the Adminer section of the documentation.

ref: https://hub.docker.com/_/adminer

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
