### PR TITLE
Update certbot run-certbot.sh to allow it work with multiple domains

### DIFF
--- a/certbot/run-certbot.sh
+++ b/certbot/run-certbot.sh
@@ -2,5 +2,6 @@
 
 letsencrypt certonly --webroot -w /var/www/letsencrypt -d "$CN" --agree-tos --email "$EMAIL" --non-interactive --text
 
-cp /etc/letsencrypt/archive/"$CN"/cert1.pem /var/certs/cert1.pem
-cp /etc/letsencrypt/archive/"$CN"/privkey1.pem /var/certs/privkey1.pem
+cp /etc/letsencrypt/archive/"$CN"/cert1.pem /var/certs/"$CN"-cert1.pem
+cp /etc/letsencrypt/archive/"$CN"/privkey1.pem /var/certs/"$CN"-privkey1.pem
+


### PR DESCRIPTION
Previously, running docker-compose up -d certbot would overwrite the previous certificate stored in /var/certs

Now: the certificates will be stored with the filename containing the domain name

## Description


## Motivation and Context
It allows to create and store SSL certificates for multiple domains

