### PR TITLE
fix unrecognized options GD config on php 7.4

### DIFF
--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -57,7 +57,11 @@ RUN if [ ${INSTALL_BZ2} = true ]; then \
 ARG INSTALL_GD=false
 RUN if [ ${INSTALL_GD} = true ]; then \
    apk add --update --no-cache freetype-dev libjpeg-turbo-dev jpeg-dev libpng-dev; \
-   docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/ && \
+   if [ ${LARADOCK_PHP_VERSION} = "7.4" ]; then \
+      docker-php-ext-configure gd --with-freetype --with-jpeg; \
+   else \
+      docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/; \
+   fi && \
    docker-php-ext-install gd \
 ;fi
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix `configure: WARNING: unrecognized options: --with-freetype-dir, --with-jpeg-dir, --with-png-dir` on PHP 7.4 #2662 
<!--- If it fixes an open issue, please link to the issue here.    -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
it allows to configure gd library on laravel-horizon for php 7.4

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
