### PR TITLE
Upgrade the Compose file format version to 3.5

### DIFF
--- a/docker-compose.sync.yml
+++ b/docker-compose.sync.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 networks:
   frontend:
@@ -848,11 +848,11 @@ services:
 ### MeiliSearch ##########################################
     meilisearch:
       image: getmeili/meilisearch:latest
-      volumes: 
+      volumes:
         - ${DATA_PATH_HOST}/meilisearch:/var/lib/meilisearch
-      ports: 
+      ports:
         - "${MEILISEARCH_HOST_PORT}:7700"
-      networks: 
+      networks:
         - frontend
         - backend
 
@@ -1371,7 +1371,7 @@ services:
     docker-in-docker:
       image: docker:19.03-dind
       environment:
-        DOCKER_TLS_SAN: DNS:docker-in-docker      
+        DOCKER_TLS_SAN: DNS:docker-in-docker
       privileged: true
       volumes:
         - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upgrade Compose file format version to 3.5

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
Since Laradock requires Docker Engine >= 17.12
https://github.com/laradock/laradock/blob/89c9cfe09941bead05d63ec3c0fe9b9173ce0526/DOCUMENTATION/content/getting-started/index.md#L7-L10

Upgrading the Compose file format version to 3.5 will allow users to use more features.
https://github.com/docker/docker.github.io/blob/f4b16104d317e08247b567a68c3c26c0e788a5d1/_includes/content/compose-matrix.md#L1-L8
![image](https://user-images.githubusercontent.com/1116129/100983438-48e73800-3584-11eb-93de-504d2ec9da28.png)

For example, setting workdir for exec is not supported in API < 1.35.


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
