### PR TITLE
Force xDebug v2 for workspace

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -350,9 +350,26 @@ USER root
 ARG INSTALL_XDEBUG=false
 
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
-    # Load the xdebug extension only with phpunit commands
-    apt-get install -y php${LARADOCK_PHP_VERSION}-xdebug && \
-    sed -i 's/^;//g' /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/20-xdebug.ini \
+  # Install the xdebug extension
+  if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
+    pecl install xdebug-2.5.5; \
+  else \
+    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ]; then \
+      pecl install xdebug-2.9.0; \
+    else \
+      if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ]; then \
+        pecl install xdebug-2.9.8; \
+      else \
+        if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
+          pecl install xdebug-2.9.8; \
+        else \
+          #pecl install xdebug; \
+          echo "xDebug 3 required, not supported."; \
+        fi \
+      fi \
+    fi \
+  fi && \
+  echo "zend_extension=xdebug.so" >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/20-xdebug.ini \
 ;fi
 
 # ADD for REMOTE debugging


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Force xDebug v2 for workspace. Maintains compatibility with existing laradock usage, and matches the ini files currently in use.
<!--- If it fixes an open issue, please link to the issue here. -->
#2794 

## Motivation and Context
Currently turning on xDebug doesn't work properly because the version and ini files are out of sync. Anyone already using laradock that has made changes is also expecting xDebug v2. 
Blindly updating to xDebug v3 would be a breaking change.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [n/a] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
