### PR TITLE
moving php.ini variables for phpmyadmin to env-example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -864,6 +864,9 @@ services:
         - MYSQL_USER=${PMA_USER}
         - MYSQL_PASSWORD=${PMA_PASSWORD}
         - MYSQL_ROOT_PASSWORD=${PMA_ROOT_PASSWORD}
+        - MAX_EXECUTION_TIME=${PMA_MAX_EXECUTION_TIME}
+        - MEMORY_LIMIT=${PMA_MEMORY_LIMIT}
+        - UPLOAD_LIMIT=${PMA_UPLOAD_LIMIT}
       ports:
         - "${PMA_PORT}:80"
       depends_on:

--- a/env-example
+++ b/env-example
@@ -483,6 +483,9 @@ PMA_USER=default
 PMA_PASSWORD=secret
 PMA_ROOT_PASSWORD=secret
 PMA_PORT=8081
+PMA_MAX_EXECUTION_TIME=600
+PMA_MEMORY_LIMIT=256M
+PMA_UPLOAD_LIMIT=2G
 
 ### MAILDEV ###############################################
 

--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -5,10 +5,5 @@ LABEL maintainer="Bo-Yi Wu <appleboy.tw@gmail.com>"
 # Add volume for sessions to allow session persistence
 VOLUME /sessions
 
-RUN echo '' >> /usr/local/etc/php/conf.d/php-phpmyadmin.ini \
- && echo '[PHP]' >> /usr/local/etc/php/conf.d/php-phpmyadmin.ini \
- && echo 'post_max_size = 2G' >> /usr/local/etc/php/conf.d/php-phpmyadmin.ini \
- && echo 'upload_max_filesize = 2G' >> /usr/local/etc/php/conf.d/php-phpmyadmin.ini
-
 # We expose phpMyAdmin on port 80
 EXPOSE 80


### PR DESCRIPTION
## Description
Moving standard variables from [https://hub.docker.com/r/phpmyadmin/phpmyadmin/](https://hub.docker.com/r/phpmyadmin/phpmyadmin/) to env-example to fix max upload file size

## Motivation and Context
Fix #2839 and modify #2389 commit for better variable management

## Types of Changes

- [x] - Bug fix (non-breaking change which fixes an issue).
- [ ] - New feature (non-breaking change which adds functionality).
- [ ] - Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] - I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] - I've updated the documentation. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] - I enjoyed my time contributing and making developer's life easier :)