### PR TITLE
workspace_redis_fix

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -559,8 +559,8 @@ RUN if [ ${INSTALL_GEARMAN} = true ]; then \
 ARG INSTALL_PHPREDIS=false
 
 RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
-    apt-get update -yqq && \
-    apt-get install -yqq php-redis \
+    pecl install redis && \
+    echo "extension=redis.so \n" >> /etc/php/${LARADOCK_PHP_VERSION}/cli/php.ini \
 ;fi
 
 ###########################################################################


### PR DESCRIPTION
## Description
Hi.
I changed redis installation and added enabling redis php extension in workspace container.
Redis extension was not enabled at all.
And I changed redis installation because of [this issue](https://stackoverflow.com/questions/33994039/phpredis-extension-doesnt-work-unable-to-load-redis-so)
I used James M's answer

## Motivation and Context
With this changes in workspace container I can run

`php artisan command:some_command_using_redis`

without error

`Class 'Redis' not found`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- New feature (non-breaking change which adds functionality).
- Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
