### PR TITLE
fix(aerospike extension): turn off build in Travis due to image version

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -18,6 +18,7 @@ if [ -n "${PHP_VERSION}" ]; then
     if [ "${PHP_VERSION}" == "5.6" ]; then
         # Aerospike C Client SDK 4.0.7, Debian 9.6 is not supported
         # https://github.com/aerospike/aerospike-client-php5/issues/145
+        sed -i -- 's/WORKSPACE_INSTALL_AEROSPIKE=true/WORKSPACE_INSTALL_AEROSPIKE=false/g' .env
         sed -i -- 's/PHP_FPM_INSTALL_AEROSPIKE=true/PHP_FPM_INSTALL_AEROSPIKE=false/g' .env
     fi
     if [ "${PHP_VERSION}" == "7.3" ]; then

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -886,9 +886,9 @@ RUN set -xe; \
               && make install \
           ) \
         else \
-          echo "AEROSPIKE does not support PHP 8.0"
-        fi \
-      fi \
+          echo "AEROSPIKE does not support PHP 8.0" \
+        ;fi \
+      ;fi \
     && rm /tmp/aerospike-client-php.tar.gz \
     && echo 'extension=aerospike.so' >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/aerospike.ini \
     && echo 'aerospike.udf.lua_system_path=/usr/local/aerospike/lua' >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/aerospike.ini \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -872,18 +872,22 @@ RUN set -xe; \
     && \
       if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
         ( \
-            cd /tmp/aerospike-client-php/src/aerospike \
-            && phpize \
-            && ./build.sh \
-            && make install \
+          cd /tmp/aerospike-client-php/src/aerospike \
+          && phpize \
+          && ./build.sh \
+          && make install \
         ) \
       else \
-        ( \
-            cd /tmp/aerospike-client-php/src \
-            && phpize \
-            && ./build.sh \
-            && make install \
-        ) \
+        if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
+          ( \
+              cd /tmp/aerospike-client-php/src \
+              && phpize \
+              && ./build.sh \
+              && make install \
+          ) \
+        else \
+          echo "AEROSPIKE does not support PHP 8.0"
+        fi \
       fi \
     && rm /tmp/aerospike-client-php.tar.gz \
     && echo 'extension=aerospike.so' >> /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/aerospike.ini \


### PR DESCRIPTION
## Description
Base image (Ubuntu 18) is no supported by Aerospike. So turn it off for the building process.
Closes #2881

## Motivation and Context
Avoid errors in the Travis CI to get better testing other stuff.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
