### PR TITLE
use standardized host.docker.internal for docker host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
         - docker-in-docker:/certs/client
         - ./php-worker/supervisord.d:/etc/supervisord.d
       extra_hosts:
-        - "dockerhost:${DOCKER_HOST_IP}"
+        - "host.docker.internal:${DOCKER_HOST_IP}"
       ports:
         - "${WORKSPACE_SSH_PORT}:22"
         - "${WORKSPACE_BROWSERSYNC_HOST_PORT}:3000"
@@ -288,7 +288,7 @@ services:
       expose:
         - "9000"
       extra_hosts:
-        - "dockerhost:${DOCKER_HOST_IP}"
+        - "host.docker.internal:${DOCKER_HOST_IP}"
       environment:
         - PHP_IDE_CONFIG=${PHP_IDE_CONFIG}
         - DOCKER_HOST=tcp://docker-in-docker:2376
@@ -346,7 +346,7 @@ services:
       depends_on:
         - workspace
       extra_hosts:
-        - "dockerhost:${DOCKER_HOST_IP}"
+        - "host.docker.internal:${DOCKER_HOST_IP}"
       networks:
         - backend
 ### Laravel Horizon ############################################
@@ -382,7 +382,7 @@ services:
       depends_on:
         - workspace
       extra_hosts:
-        - "dockerhost:${DOCKER_HOST_IP}"
+        - "host.docker.internal:${DOCKER_HOST_IP}"
       networks:
         - backend
 
@@ -1346,7 +1346,7 @@ services:
         - ${DATA_PATH_HOST}/portainer_data:/data
         - /var/run/docker.sock:/var/run/docker.sock
       extra_hosts:
-        - "dockerhost:${DOCKER_HOST_IP}"
+        - "host.docker.internal:${DOCKER_HOST_IP}"
       ports:
         - 9010:9000
       networks:


### PR DESCRIPTION
## Description
Containers are making DNS requests to host.docker.internal, but it does not resolve because laradock uses dockerhost instead.

Fixes #2966

## Motivation and Context
Found this problem while debugging why unit tests ran slow when offline. The DNS requests were timing out because there is no local entry for host.docker.internal.

References:
- https://github.com/docker/for-linux/issues/264
- https://github.com/moby/moby/pull/40007
- https://docs.docker.com/engine/release-notes/#networking-2 for docker-engine 20.10

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
