### PR TITLE
give laradock the ability to install custom composer version

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -147,7 +147,12 @@ RUN echo "" >> ~/.bashrc && \
 # Update composer
 ARG COMPOSER_VERSION=2
 ENV COMPOSER_VERSION ${COMPOSER_VERSION}
-RUN composer self-update --${COMPOSER_VERSION}
+RUN set -eux; \
+      if [ "$COMPOSER_VERSION" = "1" ] || [ "$COMPOSER_VERSION" = "2" ]; then \
+          composer self-update --${COMPOSER_VERSION}; \
+      else \
+          composer self-update ${COMPOSER_VERSION}; \
+      fi
 
 USER laradock
 


### PR DESCRIPTION
## Description
Give laradock the ability to install custom composer version
Related issue  #2978

## Motivation and Context
i want to install composer version 1.6.3 and the command `composer self-update ` takes --1 or --2 to update to the stable version of these two major versions i want to install this version using this ENV `WORKSPACE_COMPOSER_VERSION=1.6.3` and this is not working so this PR solves this problem 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
