### PR TITLE
Documentation Fix: Correct port number on phpmyadmin setup

### DIFF
--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -958,7 +958,7 @@ More details about this [here](https://github.com/jenssegers/laravel-mongodb#ins
     docker-compose up -d mariadb phpmyadmin
     ```
     *Note: To use with MariaDB, open `.env` and set `PMA_DB_ENGINE=mysql` to `PMA_DB_ENGINE=mariadb`.*
-2. Open your browser and visit the localhost on port **8080**:  `http://localhost:8080`
+2. Open your browser and visit the localhost on port **8081**:  `http://localhost:8081`, use server: "mysql", user: "default" and password: "secret for the default mysql setup.  
 
 
 


### PR DESCRIPTION
Port was 8080 but the default is set to 8081

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
