### PR TITLE
Changed startup.sh from supervisord to apache2ctl

### DIFF
--- a/apache2/startup.sh
+++ b/apache2/startup.sh
@@ -17,5 +17,5 @@ if [ ${APACHE_HTTP2} = true ]; then
   service apache2 restart
 fi
 
-# Start supervisord in foreground
-supervisord
+# Start apache in foreground
+/usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
## Description
In favor of https://github.com/laradock/laradock/issues/2928 changed the entrypoint from `supervisord ` to `apache2ctl` in the file `apache2/startup.sh`

So far tested by me, everything works normally, no more log files being generated as mentioned in the issue.


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
