### PR TITLE
PHP-FPM: Fixed INSTALL_SMB build failure.

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -787,7 +787,7 @@ RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
 ARG INSTALL_SMB=false
 
 RUN if [ ${INSTALL_SMB} = true ]; then \
-    apt-get install    apt-get install -yqq smbclient libsmbclient-dev coreutils && \
+    apt-get install -yqq smbclient libsmbclient-dev coreutils && \
     pecl install smbclient && \
     docker-php-ext-enable smbclient \
 ;fi


### PR DESCRIPTION
## Description
There's an error in the `php-fpm/Dockerfile`. In the `${INSTALL_SMB}` block on line 790, it has 'apt-get install apt-get install`.

## Motivation and Context
It solves an issue when trying to install SMB. In it's current state, the SMB install will cause the build to fail.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)

The documentation doesn't need to be updated in this scenario.