### PR TITLE
:sparkles: Add mongo crendentials to environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -612,6 +612,8 @@ RETHINKDB_PORT=8090
 ### MONGODB ###############################################
 
 MONGODB_PORT=27017
+MONGO_USERNAME=root
+MONGO_PASSWORD=example
 
 ### CADDY #################################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -656,6 +656,9 @@ services:
       build: ./mongo
       ports:
         - "${MONGODB_PORT}:27017"
+      environment:
+        - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME}
+        - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD}
       volumes:
         - ${DATA_PATH_HOST}/mongo:/data/db
         - ${DATA_PATH_HOST}/mongo_config:/data/configdb

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -787,7 +787,7 @@ RUN if [ ${INSTALL_IMAGEMAGICK} = true ]; then \
 ARG INSTALL_SMB=false
 
 RUN if [ ${INSTALL_SMB} = true ]; then \
-    apt-get install    apt-get install -yqq smbclient libsmbclient-dev coreutils && \
+    apt-get install -yqq smbclient libsmbclient-dev coreutils && \
     pecl install smbclient && \
     docker-php-ext-enable smbclient \
 ;fi


### PR DESCRIPTION
## Description
Mongo crendentials arn't provided by default so we can't setup our own credentials.

## Motivation and Context
Secure environments

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

Thanks !
