### PR TITLE
Migrate to official DockerHub repository

### DIFF
--- a/phpmyadmin/Dockerfile
+++ b/phpmyadmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM phpmyadmin/phpmyadmin
+FROM phpmyadmin
 
 LABEL maintainer="Bo-Yi Wu <appleboy.tw@gmail.com>"
 


### PR DESCRIPTION
## Description
Migrate to official DockerHub repository `phpmyadmin` from `phpmyadmin/phpmyadmin`

## Motivation and Context
From readme of [phpmyadmin/docker](https://github.com/phpmyadmin/docker)
> Note that since phpMyAdmin has been accepted in to the official DockerHub repository, you can use either that or this older phpMyAdmin repository for your Docker installation. This is maintained as a courtesy to users who have not migrated.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)


P.S. version from `phpmyadmin` supports `caching_sha2_password`, that makes me happy :)