### PR TITLE
Extension for Oracle Database, php 8.0

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -914,6 +914,8 @@ RUN if [ ${INSTALL_OCI8} = true ]; then \
     echo 'instantclient,/opt/oracle/instantclient_12_1/' | pecl install oci8-2.0.12; \
   elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
     echo 'instantclient,/opt/oracle/instantclient_12_1/' | pecl install oci8-2.2.0; \
+  elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "80000" ]; then \
+    echo 'instantclient,/opt/oracle/instantclient_12_1/' | pecl install oci8-3.0.1; \
   else \
     echo 'instantclient,/opt/oracle/instantclient_12_1/' | pecl install oci8; \
   fi \


### PR DESCRIPTION
## Description
Add Extension for Oracle Database php 8.0 

https://pecl.php.net/package/oci8

The OCI8 extension lets you access Oracle Database.
Use 'pecl install oci8' to install for PHP 8.1.
Use 'pecl install oci8-3.0.1' to install for PHP 8.0.
Use 'pecl install oci8-2.2.0' to install for PHP 7.
Use 'pecl install oci8-2.0.12' to install for PHP 5.2 - PHP 5.6.
Use 'pecl install oci8-1.4.10' to install for PHP 4.3.9 - PHP 5.1.)

## Motivation and Context
error in build dockerfile workspace:
```
pecl/oci8 requires PHP (version >= 8.1.0), installed version is 8.0.13
```

