### PR TITLE
PostGIS - 1)Add PostGIS VERSION and 2)add option to install 'pgsql-http' ext

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -445,7 +445,6 @@ POSTGRES_ENTRYPOINT_INITDB=./postgres/docker-entrypoint-initdb.d
 
 ### POSTGIS ##############################################
 
-POSTGIS_VERSION=latest
 POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13=false
 
 ### SQS ##############################################

--- a/.env.example
+++ b/.env.example
@@ -443,6 +443,11 @@ POSTGRES_PASSWORD=secret
 POSTGRES_PORT=5432
 POSTGRES_ENTRYPOINT_INITDB=./postgres/docker-entrypoint-initdb.d
 
+### POSTGIS ##############################################
+
+POSTGIS_VERSION=latest
+POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13=false
+
 ### SQS ##############################################
 
 SQS_NODE_HOST_PORT=9324

--- a/.env.example
+++ b/.env.example
@@ -443,7 +443,7 @@ POSTGRES_PASSWORD=secret
 POSTGRES_PORT=5432
 POSTGRES_ENTRYPOINT_INITDB=./postgres/docker-entrypoint-initdb.d
 
-### POSTGIS ##############################################
+### POSTGRES-POSTGIS ##############################################
 
 POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -619,7 +619,10 @@ services:
 
 ### PostgreSQL PostGis ###################################
     postgres-postgis:
-      build: ./postgres-postgis
+      build:
+        context: ./postgres-postgis
+        args:
+          - POSTGRES_VERSION=${POSTGRES_VERSION}   
       volumes:
         - ${DATA_PATH_HOST}/postgres:/var/lib/postgresql/data
       ports:
@@ -628,6 +631,7 @@ services:
         - POSTGRES_DB=${POSTGRES_DB}
         - POSTGRES_USER=${POSTGRES_USER}
         - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+        - INSTALL_PGSQL_HTTP_FOR_POSTGIS13=${POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13}
       networks:
         - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -623,6 +623,7 @@ services:
         context: ./postgres-postgis
         args:
           - POSTGRES_VERSION=${POSTGRES_VERSION}   
+          - INSTALL_PGSQL_HTTP_FOR_POSTGIS13=${POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13}
       volumes:
         - ${DATA_PATH_HOST}/postgres:/var/lib/postgresql/data
       ports:
@@ -631,7 +632,6 @@ services:
         - POSTGRES_DB=${POSTGRES_DB}
         - POSTGRES_USER=${POSTGRES_USER}
         - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-        - INSTALL_PGSQL_HTTP_FOR_POSTGIS13=${POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13}
       networks:
         - backend
 

--- a/postgres-postgis/Dockerfile
+++ b/postgres-postgis/Dockerfile
@@ -1,7 +1,24 @@
-ARG POSTGRES_VERSION=alpine
+ARG POSTGRES_VERSION=latest
 FROM postgis/postgis:${POSTGRES_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
+
+RUN if [ ${INSTALL_PGSQL_HTTP_FOR_POSTGIS13} = true ]; then \
+    apt-get clean \
+    && apt-get update -yqq \
+    && apt-get install -y \
+        git \
+        make \
+        gcc \ 
+        libcurl4-openssl-dev \
+        postgresql-server-dev-13 \
+        postgresql-13-cron \
+    && git clone --recursive https://github.com/pramsey/pgsql-http.git \
+    && cd pgsql-http/ \
+    && make \
+    && make install \
+    && apt-get clean \
+;fi
 
 CMD ["postgres"]
 

--- a/postgres-postgis/Dockerfile
+++ b/postgres-postgis/Dockerfile
@@ -9,7 +9,7 @@ RUN if [ ${INSTALL_PGSQL_HTTP_FOR_POSTGIS13} = true ]; then \
     && apt-get install -y \
         git \
         make \
-        gcc \ 
+        gcc \
         libcurl4-openssl-dev \
         postgresql-server-dev-13 \
         postgresql-13-cron \

--- a/postgres-postgis/Dockerfile
+++ b/postgres-postgis/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgis/postgis:latest
+ARG POSTGRES_VERSION=alpine
+FROM postgis/postgis:${POSTGRES_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/postgres-postgis/Dockerfile
+++ b/postgres-postgis/Dockerfile
@@ -3,6 +3,8 @@ FROM postgis/postgis:${POSTGRES_VERSION}
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 
+ARG INSTALL_PGSQL_HTTP_FOR_POSTGIS13=false
+
 RUN if [ ${INSTALL_PGSQL_HTTP_FOR_POSTGIS13} = true ]; then \
     apt-get clean \
     && apt-get update -yqq \


### PR DESCRIPTION
1. Add Postgres version to install (use `POSTGRES_VERSION` variable)
2. Add variable (`POSTGIS_INSTALL_PGSQL_HTTP_FOR_POSTGIS13`) to install `pgsql-http` (https://github.com/pramsey/pgsql-http.git) extension.

Issue: https://github.com/laradock/laradock/issues/3115