### PR TITLE
Update docker-in-docker tag image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1516,7 +1516,7 @@ services:
 
 ### Docker-in-Docker ################################################
     docker-in-docker:
-      image: docker:19.03-dind
+      image: docker:20.10-dind
       environment:
         DOCKER_TLS_SAN: DNS:docker-in-docker
       privileged: true


### PR DESCRIPTION
Update docker-in-docker tag image to 20.10; it solve the bug:
```
cgroup mountpoint does not exist: unknown
```

running a container.