### PR TITLE
fix meilisearch volume mount path closes #3138

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -995,7 +995,7 @@ services:
     meilisearch:
       image: getmeili/meilisearch:latest
       volumes:
-        - ${DATA_PATH_HOST}/meilisearch:/var/lib/meilisearch
+        - ${DATA_PATH_HOST}/meilisearch:/data.ms
       ports:
         - "${MEILISEARCH_HOST_PORT}:7700"
       networks:


### PR DESCRIPTION
## Description
Fixes issue #3138 

## Motivation and Context
Meilisearch wasn't persisting data when bringing up new container due to incorrectly mounted volume

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
