### PR TITLE
Do not install tokenizer into php-worker when php version is 8.1

### DIFF
--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -38,7 +38,12 @@ RUN apk --update add wget \
 
 
 RUN pecl channel-update pecl.php.net; \
-  docker-php-ext-install mysqli mbstring pdo pdo_mysql tokenizer xml pcntl
+  docker-php-ext-install mysqli mbstring pdo pdo_mysql xml pcntl; \
+  if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ]; then \
+    php -m | grep -q 'tokenizer'; \
+  else \
+    docker-php-ext-install tokenizer; \
+  fi
 
 # Add a non-root user:
 ARG PUID=1000


### PR DESCRIPTION
## Description

This pull request fixes the tokeniser error when you build php-worker with 8.1 php version.
```env
# Select a PHP version of the Workspace and PHP-FPM containers (Does not apply to HHVM).
# Accepted values: 8.0 - 7.4 - 7.3 - 7.2 - 7.1 - 7.0 - 5.6
PHP_VERSION=8.1
```

Given error :
```shell
$ docker-compose build --no-cache php-worker
...
#7 47.30 creating libtool
#7 47.33 appending configuration tag "CXX" to libtool
#7 47.40 configure: patching config.h.in
#7 47.40 configure: creating ./config.status
#7 47.44 config.status: creating config.h
#7 47.47 make: *** No rule to make target '/usr/src/php/ext/tokenizer/Zend/zend_language_parser.y', needed by '/usr/src/php/ext/tokenizer/Zend/zend_language_parser.c'.  Stop.
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c pecl channel-update pecl.php.net;   docker-php-ext-install mysqli mbstring pdo pdo_mysql tokenizer xml pcntl]: exit code: 2
```


Also, tokeniser is already installed on php 8.1 docker image, which is the default image used in order to build php-worker
```shell
$ docker run --rm php:8.1-alpine php -m | grep -i token
tokenizer
```

I think the change can be applied to all php version, as tokeniser is installed by default, but, I preferred to *not* install it only for php 8.1, as the installation process works for previous php versions.

Related issues : https://github.com/laradock/laradock/issues/3109#issuecomment-1014403616

## Motivation and Context

I want to upgrade my laravel project to php 8.1 and I need php-worker working.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
