### PR TITLE
Update php 'FROM' tag to use PHP8.1

### DIFF
--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 ARG LARADOCK_PHP_VERSION
-FROM php:${LARADOCK_PHP_VERSION}-alpine3.13
+FROM php:${LARADOCK_PHP_VERSION}-alpine3.15
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 ARG LARADOCK_PHP_VERSION
-FROM php:${LARADOCK_PHP_VERSION}-alpine
+FROM php:${LARADOCK_PHP_VERSION}-alpine3.15
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 


### PR DESCRIPTION
As described here:
- https://github.com/laradock/laradock/issues/3163

fixed the `alpine` tag for PHP version <= 8.1.

In addition, as commented here:
- https://github.com/laradock/laradock/issues/3008#issuecomment-886003556

the same thing should be done for `php-worker`; done!

