### PR TITLE
Fix sqlsrv latest not support PHP 7.3

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1081,6 +1081,8 @@ RUN set -eux; \
         pecl install pdo_sqlsrv-5.6.1 sqlsrv-5.6.1 \
       ;elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70200" ]; then \
         pecl install pdo_sqlsrv-5.8.1 sqlsrv-5.8.1 \
+      ;elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70300" ]; then \
+        pecl install pdo_sqlsrv-5.9.0 sqlsrv-5.9.0 \
       ;else \
         pecl install pdo_sqlsrv sqlsrv \
       ;fi && \


### PR DESCRIPTION
## Description
Fix pdo_sqlsrv and sqlsrv latest not support php 7.3 in workspace.

## Motivation and Context
pdo_sqlsrv and sqlsrv latest not support php 7.3

![image](https://user-images.githubusercontent.com/20652466/157217626-c6ea6bbe-c3cc-4d4c-a5eb-4e44073f1b0a.png)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)