### PR TITLE
Solved undefined function imagecreatefromjpeg

### DIFF
--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -87,7 +87,7 @@ ARG INSTALL_GD=false
 RUN if [ ${INSTALL_GD} = true ]; then \
   apk add --update --no-cache freetype-dev libjpeg-turbo-dev jpeg-dev libpng-dev; \
   if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "4" ]; then \
-  docker-php-ext-configure gd --with-freetype --with-jpeg --with-png; \
+  docker-php-ext-configure gd --with-freetype --with-jpeg; \
   else \
   docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/; \
   fi; \


### PR DESCRIPTION

## Description
[Solved] `Call to undefined function Intervention\Image\Gd\imagecreatefromjpeg()`

[PHP 7.4 Changelog](https://www.php.net/manual/en/migration74.other-changes.php) in GD section in PHP 7.4(Alpine)

we can run docker-php-ext-configure command to configure our gd with JPEG support. 
we don't need to provide flag to enable PNG.

```
$ docker exec -it laradock_php-worker_1 php -r 'print_r(gd_info());'
Array
(
    [GD Version] => bundled (2.1.0 compatible)
    [FreeType Support] => 1
    [FreeType Linkage] => with freetype
    [GIF Read Support] => 1
    [GIF Create Support] => 1
    [JPEG Support] => 1
    [PNG Support] => 1
    [WBMP Support] => 1
    [XPM Support] => 
    [XBM Support] => 1
    [WebP Support] => 
    [BMP Support] => 1
    [TGA Read Support] => 1
    [JIS-mapped Japanese Font Support] => 
)
```


## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
