### PR TITLE
Use the maintained version of maildev

### DIFF
--- a/maildev/Dockerfile
+++ b/maildev/Dockerfile
@@ -1,5 +1,5 @@
-FROM djfarrelly/maildev
+FROM maildev/maildev
 
-LABEL maintainer="Maxime Hélias <maximehelias16@gmail.com>"
+LABEL maintainer="Dan Farrelly"
 
 EXPOSE 80 25


### PR DESCRIPTION
## Description
This will make laradoc use the version of maildev that is actually maintained
https://hub.docker.com/r/maildev/maildev/tags

## Motivation and Context
The old place for maildev (djfarrelly/maildev) is not maintained any more.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
