### PR TITLE
fix redis workspace php-redis 404

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -533,6 +533,7 @@ RUN if [ ${INSTALL_GEARMAN} = true ]; then \
 ARG INSTALL_PHPREDIS=false
 
 RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
+    apt-get update && \
     apt-get install -yqq php${LARADOCK_PHP_VERSION}-redis \
 ;fi
 


### PR DESCRIPTION
## Description
E: Failed to fetch http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/p/php-redis/php7.3-redis_5.3.6+4.3.0-1+ubuntu20.04.1+deb.sury.org+1_arm64.deb 404 Not Found [IP: 185.125.190.52 80] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing

## Motivation and Context
fix php-redis 404 Not Found

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
