### PR TITLE
Fix MeiliSearch volume mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1014,7 +1014,7 @@ services:
     meilisearch:
       image: getmeili/meilisearch:latest
       volumes:
-        - ${DATA_PATH_HOST}/meilisearch:/data.ms
+        - ${DATA_PATH_HOST}/meilisearch:/meili_data/data.ms
       ports:
         - "${MEILISEARCH_HOST_PORT}:7700"
       networks:


### PR DESCRIPTION
## Description
The MeiliSearch data path changed in release 0.27 of MeiliSearch - the path needs to be updated in the Laradock docker-compose.yml too.

## Motivation and Context
The changed data path leads do data loss after each restart of the container - no data gets persisted which can get pretty annoying during development.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
