### PR TITLE
added pcov for php 8.x

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -375,8 +375,8 @@ USER root
 ARG INSTALL_PCOV=false
 
 RUN if [ ${INSTALL_PCOV} = true ]; then \
-  if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
-    if [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
+  if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] || [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ]; then \
+    if [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ] || [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ]; then \
       pecl install pcov && \
       echo "extension=pcov.so" >> /etc/php/${LARADOCK_PHP_VERSION}/cli/php.ini && \
       echo "pcov.enabled" >> /etc/php/${LARADOCK_PHP_VERSION}/cli/php.ini \


### PR DESCRIPTION
## Description
pcov is only installed on php >= 7.1 but not on php 8.x

## Motivation and Context
add phpcov to php 8.x installations

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
