### PR TITLE
Use correct Caddy repo to get latest version

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy/caddy:latest
+FROM caddy:latest
 
 COPY ./caddy/Caddyfile /etc/caddy/Caddyfile
 


### PR DESCRIPTION
## Description
(https://github.com/laradock/laradock/issues/3125)

## Motivation and Context
The Dockerfile in laradock references to caddy/caddy:latest which installs Caddy 2.0.0.-rc3 (with security issues!)
It should be adjusted to the official Caddy Docker repo by changing it to just caddy

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue). 

## Definition of Done Checklist:
- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
