### PR TITLE
fix php7 swoole build failed

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -322,6 +322,8 @@ RUN set -eux; \
         pecl install swoole-4.3.5; \
       elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70100" ]; then \
         pecl install swoole-4.5.11; \
+      elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
+        pecl install swoole-4.8.12; \
       else \
         pecl install swoole; \
       fi; \

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -355,6 +355,8 @@ RUN set -eux; \
       pecl install swoole-4.3.5; \
     elif [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "70100" ]; then \
       pecl install swoole-4.5.11; \
+    elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
+      pecl install swoole-4.8.12; \
     else \
       pecl install swoole; \
     fi; \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -550,6 +550,8 @@ RUN set -eux; \
         echo '' | pecl -q install swoole-4.3.5; \
       elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ]; then \
         echo '' | pecl -q install swoole-4.5.11; \
+      elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
+        echo '' | pecl -q install swoole-4.8.12; \
       else \
         echo '' | pecl -q install swoole; \
       fi; \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
php7.3 swoole build failed, as the lastest swoole version required php8.x
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
#0 0.215 + pecl install swoole
#0 20.11 pecl/swoole requires PHP (version >= 8.0.0), installed version is 7.3.33

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
