### PR TITLE
fix nginx proxy to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,6 +440,8 @@ services:
       networks:
         - frontend
         - backend
+      extra_hosts:
+        - "host.docker.internal:host-gateway"  
 
 ### OpenResty Server #########################################
     openresty:


### PR DESCRIPTION
Hello, good time
the addition of host.docker.internal to the nginx configuration.

which solves the problem of proxying with nginx to the local host.
https://github.com/laradock/laradock/issues/3317

Here someone mentioned this problem and another example of this problem along with the solution was already in the stackoverflow.
https://stackoverflow.com/questions/70725881/what-is-the-equivalent-of-add-host-host-docker-internalhost-gateway-in-a-comp

I will be happy if you confirm the request to solve the problem.