### PR TITLE
Fix Laravel Horizon container not building due to tokenizer in Dockerfile for PHP 8.2

### DIFF
--- a/laravel-horizon/Dockerfile
+++ b/laravel-horizon/Dockerfile
@@ -37,12 +37,13 @@ RUN apk --update add wget \
   procps
 
 RUN pecl channel-update pecl.php.net; \
-    docker-php-ext-install mysqli mbstring pdo pdo_mysql xml pcntl; \
-    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ]; then \
-      php -m | grep -q 'tokenizer'; \
-    else \
-      docker-php-ext-install tokenizer; \
-    fi
+  docker-php-ext-install mysqli mbstring pdo pdo_mysql xml pcntl; \
+  if [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "80100" ] || \
+     [ $(php -r "echo PHP_VERSION_ID - PHP_RELEASE_VERSION;") = "80200" ]; then \
+    php -m | grep -oiE '^tokenizer$'; \
+  else \
+    docker-php-ext-install tokenizer; \
+  fi
 
 # Add a non-root user to help install ffmpeg:
 ARG PUID=1000


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Changed laravel-horizon/Dockerfile so `docker-php-ext-install tokenizer;` isn't called for PHP 8.2.

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
The Laravel Horizon container could not be built with Laravel 8.2, same was the case for 8.1.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
