### PR TITLE
Upgrade the Compose file format version to Compose Specification

### DIFF
--- a/DOCUMENTATION/content/getting-started/index.md
+++ b/DOCUMENTATION/content/getting-started/index.md
@@ -7,7 +7,7 @@ weight: 2
 ## Requirements
 
 - [Git](https://git-scm.com/downloads)
-- [Docker](https://www.docker.com/products/docker/) [ >= 17.12 ]
+- [Docker](https://www.docker.com/products/docker-desktop/) [ >= 19.03.0 ]
 
 
 
@@ -148,12 +148,12 @@ If you use Chrome 63 or above for development, don't use `.dev`. [Why?](https://
 
 If you are using **Docker Toolbox** (VM), do one of the following:
 
-- Upgrade to Docker [Native](https://www.docker.com/products/docker) for Mac/Windows (Recommended). Check out [Upgrading Laradock](/documentation/#upgrading-laradock)
+- Upgrade to [Docker Desktop](https://www.docker.com/products/docker-desktop/) for Mac/Windows (Recommended). Check out [Upgrading Laradock](/documentation/#upgrading-laradock)
 - Use Laradock v3.\*. Visit the [Laradock-ToolBox](https://github.com/laradock/laradock/tree/LaraDock-ToolBox) branch. *(outdated)*
 
 <br>
 
-We recommend using a Docker version which is newer than 1.13. 
+We recommend using a Docker Engine version which is newer than 19.03.0.
 
 <br>
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -179,7 +179,7 @@ Homestead 是一个工具,为你控制虚拟机(使用 Homestead 特殊命令)�
 ## 依赖
 
 - [Git](https://git-scm.com/downloads)       
-- [Docker](https://www.docker.com/products/docker/)
+- [Docker](https://www.docker.com/products/docker-desktop/)
 
 <a name="Installation"></a>
 ## 安装
@@ -205,9 +205,9 @@ git clone https://github.com/laradock/laradock.git
 
 **请在开始之前阅读:**
 如果你正在使用 **Docker Toolbox** (VM)，选择以下任何一个方法：
-- 更新到 Docker [Native](https://www.docker.com/products/docker) Mac/Windows 版本 (建议). 查看 [Upgrading Laradock](#upgrading-laradock)
+- 更新到 [Docker Desktop](https://www.docker.com/products/docker-desktop/) Mac/Windows 版本 (建议). 查看 [Upgrading Laradock](#upgrading-laradock)
 - 使用 Laradock v3.* (访问 `Laradock-ToolBox` [分支](https://github.com/laradock/laradock/tree/Laradock-ToolBox)).
-如果您使用的是 **Docker Native**(Mac / Windows 版本)甚至是 Linux 版本,通常可以继续阅读这个文档，Laradock v4 以上版本将仅支持 **Docker Native**。
+如果您使用的是 **Docker Desktop**(Mac / Windows 版本)甚至是 Linux 版本,通常可以继续阅读这个文档，Laradock v4 以上版本将仅支持 **Docker Desktop**。
 
 1 - 运行容器: *(在运行 `docker-compose` 命令之前，确认你在 `laradock` 目录中*
 

--- a/docker-compose.sync.yml
+++ b/docker-compose.sync.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 networks:
   frontend:
     driver: ${NETWORKS_DRIVER}


### PR DESCRIPTION
## Description

- Remove docker-compose.yml top-level `version` property
- Require Docker Engine 19.03.0+

## Motivation and Context

Since Compose file version 3 was moved to the legacy node (https://github.com/docker/docs/pull/14416), we should let Laradock start supporting the Compose specification, which means letting the top-level `version` property be deprecated (https://docs.docker.com/compose/compose-file/#version-top-level-element).

This also eliminates the need to keep an eye on whether the version of the Docker Compose file is out of date, as it will automatically be backwards compatible.

## Types of Changes

I'm not sure...

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
