### PR TITLE
Fix logstash build error

### DIFF
--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -7,6 +7,4 @@ RUN curl -L -o /usr/share/logstash/lib/mysql-connector-java-5.1.47.jar https://r
 ADD ./pipeline/ /usr/share/logstash/pipeline/
 ADD ./config/ /usr/share/logstash/config/
 
-RUN logstash-plugin install logstash-input-jdbc
 RUN logstash-plugin install logstash-input-beats
-


### PR DESCRIPTION
## Description
Logstash Dockerfile tries to install an already bundled plugin and returns an error while building.

## Motivation and Context
This changes fixes issue #3173.
The path to the [solution](https://discuss.elastic.co/t/installation-aborted-plugin-logstash-input-jdbc-is-already-provided-by-logstash-integration-jdbc/287562) 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I enjoyed my time contributing and making developer's life easier :)
