### PR TITLE
add composer alias to turn off xdebug for composer runs

### DIFF
--- a/workspace/aliases.sh
+++ b/workspace/aliases.sh
@@ -60,6 +60,7 @@ alias egrep='egrep --color=auto'
 
 alias art="php artisan"
 alias artisan="php artisan"
+alias composer='XDEBUG_MODE=off \composer'
 alias cdump="composer dump-autoload -o"
 alias composer:dump="composer dump-autoload -o"
 alias db:reset="php artisan migrate:reset && php artisan migrate --seed"


### PR DESCRIPTION
## Description
xdebug is set to be always on within the workspace, this means things like composer run slower when you've not got a listening ide open.

this update adds the composer alias so that xdebug is turned off for duration of composer commands.

## Motivation and Context
after booting the workspace and ssh-ing into the workspace environment - ran `composer install` and due to not having an ide set to listen for connections - was presented with lots of repeated messages about could not connect to debugging client
```
Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9000 (through xdebug.client_host/xdebug.client_port).
```
![Screenshot 2023-05-16 at 19 28 36](https://github.com/laradock/laradock/assets/67553/a217a0e7-90e3-460a-88d6-8a5376a1c9ee)

adding this alias and rebuilding - then running the same `composer install` 
![Screenshot 2023-05-16 at 19 30 21](https://github.com/laradock/laradock/assets/67553/bd397e18-3b1c-4b14-9399-15542a154f33)


## Types of Changes
- [x] New feature (non-breaking change which adds functionality).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I enjoyed my time contributing and making developer's life easier :)
