### PR TITLE
fix: change the current image with the image that soketi recommends

### DIFF
--- a/soketi/Dockerfile
+++ b/soketi/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/soketi/soketi:latest
+FROM quay.io/soketi/soketi:1.4-16-debian
 
-LABEL maintainer="WuweiMing <wwm041544363@gmail.com>"
+LABEL maintainer="Carlos-vargs <cvargaslopez769@gmail.com>"
 
 CMD ["node /app/bin/server.js start"]
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
This contribution addresses a bug in Laradock related to the Soketi image. The bug was fixed by updating the base image to quay.io/soketi/soketi:1.4-16-debian. The issue caused problems with the functionality of the application, which were resolved by replacing the previous base image with the updated one. This change ensures that the application can run correctly and leverage the features provided by the updated Soketi image.


## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
The motivation behind this bug fix is to enhance the reliability and performance of Laradock. By updating the Soketi image, we ensure that the application is using the latest version with bug fixes and improvements. This change also helps in maintaining compatibility with other dependencies and frameworks within the Laradock ecosystem. The bug fix contributes to a more stable and efficient development environment, providing a smoother experience for developers working with Laradock.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]  Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x]   I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ]  I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x]  I enjoyed my time contributing and making developer's life easier :)
