### PR TITLE
fix remove file not found error

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1311,7 +1311,7 @@ USER root
 # Clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    rm /var/log/lastlog /var/log/faillog
+    rm -f /var/log/lastlog /var/log/faillog
 
 # Configure non-root user.
 ARG PUID=1000

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1838,7 +1838,7 @@ USER root
 # Clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    rm /var/log/lastlog /var/log/faillog
+    rm -f /var/log/lastlog /var/log/faillog
 
 # Set default work directory
 WORKDIR /var/www


### PR DESCRIPTION
Description
This pull request modifies the rm commands in both php-fpm/Dockerfile and workspace/Dockerfile to ignore errors if the files do not exist. This is done by adding the -f (force) option to the rm commands.

Motivation and Context
This change fixes an issue where the build process fails if the files /var/log/lastlog and /var/log/faillog do not exist in the image. By adding the -f option, rm will not produce an error and the build process can continue successfully.

Types of Changes
 Bug fix (non-breaking change which fixes an issue).
Definition of Done Checklist:
 I've read the [Contribution Guide](http://laradock.io/contributing).
 I've updated the documentation. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
 I enjoyed my time contributing and making developer's life easier :)