### PR TITLE
Update phalcon.ini

### DIFF
--- a/php-fpm/phalcon.ini
+++ b/php-fpm/phalcon.ini
@@ -1,2 +1,1 @@
-extension=psr.so
 extension=phalcon.so


### PR DESCRIPTION
Phalcon 5.x don't need psr.so.

Fix the php warning

PHP Warning:  PHP Startup: Unable to load dynamic library 'psr.so' (tried: /usr/lib/php/20210902/psr.so (/usr/lib/php/20210902/psr.so: cannot open shared object file: No such file or directory), /usr/lib/php/20210902/psr.so.so (/usr/lib/php/20210902/psr.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
