### PR TITLE
fix: fixed meilisearch not loading the master key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1035,6 +1035,8 @@ services:
         - ${DATA_PATH_HOST}/meilisearch:/data.ms
       ports:
         - "${MEILISEARCH_HOST_PORT}:7700"
+      environment:
+        - MEILI_MASTER_KEY=${MEILISEARCH_KEY}
       networks:
         - frontend
         - backend


### PR DESCRIPTION
The MEILISEARCH_KEY option has been added to the env file, but it is not being used in the docker-compose file