### PR TITLE
fix php8.2 Call to undefined function imagecreatefromjpeg

### DIFF
--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -94,7 +94,7 @@ RUN if [ ${INSTALL_GD} = true ]; then \
   if [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && [ $(php -r "echo PHP_MINOR_VERSION;") = "4" ]; then \
   docker-php-ext-configure gd --with-freetype --with-jpeg; \
   else \
-  docker-php-ext-configure gd --with-freetype-dir=/usr/lib/ --with-jpeg-dir=/usr/lib/ --with-png-dir=/usr/lib/; \
+  docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/; \
   fi; \
   docker-php-ext-install gd \
   ;fi


### PR DESCRIPTION
/etc/supervisor/conf.d # php -v
PHP 8.2.8 (cli) (built: Jul 10 2023 22:20:45) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.8, Copyright (c) Zend Technologie

before fix

/etc/supervisor/conf.d # php -m |grep gd
gd
/etc/supervisor/conf.d # php -r "var_dump(function_exists('imagecreatefromjpeg'));"
bool(false)


fix

/etc/supervisor/conf.d # php -m |grep gd
gd
/etc/supervisor/conf.d # php -r "var_dump(function_exists('imagecreatefromjpeg'));"
bool(true)


