### PR TITLE
Support configuration json on Soketi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,6 +418,8 @@ services:
     soketi:
       build:
         context: ./soketi
+      volumes:
+        - ./soketi/config.json:/app/bin/config.json:ro
       ports:
         - "${SOKETI_PORT}:6001"
         - "${SOKETI_METRICS_SERVER_PORT}:9601"

--- a/soketi/Dockerfile
+++ b/soketi/Dockerfile
@@ -1,7 +1,9 @@
-FROM quay.io/soketi/soketi:1.4-16-debian
+FROM quay.io/soketi/soketi:latest-16-debian
 
-LABEL maintainer="Carlos-vargs <cvargaslopez769@gmail.com>"
+LABEL maintainer="Er-Niebla <er.niebla@gmail.com>"
 
-CMD ["node /app/bin/server.js start"]
+COPY config.json /app/bin/config.json
+
+CMD ["--config=/app/bin/config.json"]
 
 EXPOSE 6001 9601

--- a/soketi/config.json
+++ b/soketi/config.json
@@ -1,0 +1,3 @@
+{
+    "debug": false
+}


### PR DESCRIPTION
## Motivation and Context
Upgrade `soketi:1.4` to latest `soketi:1.6`
It is necessary to have the option to change the soketi configuration
https://docs.soketi.app/getting-started/environment-variables#file-configuration
```json
{
    "debug": true,
    "appManager.array.apps": [
        {
            "id": "some-id",
            "key": "some-key",
            "secret": "some-secret",
        }
    ]
}
```
On **laravel-echo-server** we have this
https://github.com/laradock/laradock/blob/205cb4e5c948259b88a0444e55a541a3317c230a/docker-compose.yml#L1320-L1321
https://github.com/laradock/laradock/blob/205cb4e5c948259b88a0444e55a541a3317c230a/laravel-echo-server/Dockerfile#L27
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
