### PR TITLE
Add composer self-update 2.2 support

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -142,7 +142,7 @@ RUN echo "" >> ~/.bashrc && \
 ARG COMPOSER_VERSION=2
 ENV COMPOSER_VERSION ${COMPOSER_VERSION}
 RUN set -eux; \
-      if [ "$COMPOSER_VERSION" = "1" ] || [ "$COMPOSER_VERSION" = "2" ]; then \
+      if [ "$COMPOSER_VERSION" = "1" ] || [ "$COMPOSER_VERSION" = "2" ] || [ "$COMPOSER_VERSION" = "2.2" ]; then \
           composer self-update --${COMPOSER_VERSION}; \
       else \
           composer self-update ${COMPOSER_VERSION}; \


### PR DESCRIPTION
## Description
Add `composer self-update --2.2` support

## Motivation and Context
`composer self-update` has option to force update to 2.2.x LTS version.
![image](https://github.com/laradock/laradock/assets/46696647/b68779fb-8002-4e17-9a24-ce6316d39390)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I enjoyed my time contributing and making developer's life easier :)
