### PR TITLE
Don't install New Relic on PHP 8.3

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1227,8 +1227,8 @@ ARG NEW_RELIC=${NEW_RELIC}
 ARG NEW_RELIC_KEY=${NEW_RELIC_KEY}
 ARG NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME}
 
-RUN if [ ${NEW_RELIC} = true ]; then \
-  curl -L http://download.newrelic.com/php_agent/archive/10.13.0.2/newrelic-php5-10.13.0.2-linux.tar.gz | tar -C /tmp -zx && \
+RUN if [ ${NEW_RELIC} = true ] && [ ${LARADOCK_PHP_VERSION} != "8.3" ]; then \
+  curl -L http://download.newrelic.com/php_agent/archive/10.14.0.3/newrelic-php5-10.14.0.3-linux.tar.gz | tar -C /tmp -zx && \
   export NR_INSTALL_USE_CP_NOT_LN=1 && \
   export NR_INSTALL_SILENT=1 && \
   /tmp/newrelic-php5-*/newrelic-install install && \


### PR DESCRIPTION
## Description
Apparently it will take a few months for New Relic to add support for 8.3, it would be better to add a condition until then
https://github.com/laradock/laradock/pull/3485#issuecomment-1837183328
https://github.com/laradock/laradock/pull/3485#issuecomment-1836468211
Also bump version

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
