### PR TITLE
Fix certbot once and for all

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1094,3 +1094,7 @@ KEYCLOAK_POSTGRES_DB=laradock_keycloak
 ### Mailpit #################################################
 MAILPIT_HTTP_PORT=8125
 MAILPIT_SMTP_PORT=1125
+
+### Certbot #################################################
+CERTBOT_CN=yourhost.tld
+CERTBOT_EMAIL=youremail@domain.tld

--- a/DOCUMENTATION/content/documentation/index.md
+++ b/DOCUMENTATION/content/documentation/index.md
@@ -2617,6 +2617,22 @@ docker-compose up ...
 
 *Note: If you faced any errors, try restarting Docker, and make sure you have no spaces in the `d4m-nfs-mounts.txt` file, and your `/etc/exports` file is clear.*
 
+<br>
+<a name="certbot"></a>
+## certbot
+
+To start using certbot, you can add or edit the variables `CERTBOT_CN` and `CERTBOT_EMAIL` in your `.env` file.
+If you'd like renewals to happen via `nginx` be sure to `docker compose up -d nginx` as well.
+Otherwise, it is advised to use DNS Renewals. `(certbot dns-challenge)`
+To auto renew your certificates, you can add a cron job to your host machine.
+eg: add the following to your `cron.weekly`
+```bash
+cd <path-to-your-laradock-install> \
+&& docker compose --env-file=.env up certbot 2>&1 | grep -q 'Keeping the existing certificate' \
+|| docker compose exec -T nginx nginx -s reload
+```
+
+Certs can be found in: `${DATA_PATH_HOST}/certbot/certs/`
 
 <br>
 <a name="ca-certificates"></a>

--- a/certbot/run-certbot.sh
+++ b/certbot/run-certbot.sh
@@ -2,8 +2,8 @@
 
 letsencrypt certonly --webroot -w /var/www/letsencrypt -d "$CN" --agree-tos --email "$EMAIL" --non-interactive --text
 
-cp /etc/letsencrypt/archive/"$CN"/cert1.pem /var/certs/"$CN"-cert1.pem
-cp /etc/letsencrypt/archive/"$CN"/chain1.pem /var/certs/chain1.pem
-cp /etc/letsencrypt/archive/"$CN"/fullchain1.pem /var/certs/fullchain1.pem
-cp /etc/letsencrypt/archive/"$CN"/privkey1.pem /var/certs/"$CN"-privkey1.pem
+cp /etc/letsencrypt/live/"$CN"/cert1.pem /var/certs/"$CN"-cert1.pem
+cp /etc/letsencrypt/live/"$CN"/chain1.pem /var/certs/"$CN"-chain1.pem
+cp /etc/letsencrypt/live/"$CN"/fullchain1.pem /var/certs/"$CN"-fullchain1.pem
+cp /etc/letsencrypt/live/"$CN"/privkey1.pem /var/certs/"$CN"-privkey1.pem
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,6 +444,7 @@ services:
         - ${NGINX_HOST_LOG_PATH}:/var/log/nginx
         - ${NGINX_SITES_PATH}:/etc/nginx/sites-available
         - ${NGINX_SSL_PATH}:/etc/nginx/ssl
+        - ./certbot/letsencrypt/:/var/www/letsencrypt
       ports:
         - "${NGINX_HOST_HTTP_PORT}:80"
         - "${NGINX_HOST_HTTPS_PORT}:443"
@@ -1147,7 +1148,7 @@ services:
       build:
         context: ./certbot
       volumes:
-        - ./data/certbot/certs/:/var/certs
+        - ${DATA_PATH_HOST}/certbot/certs/:/var/certs
         - ./certbot/letsencrypt/:/var/www/letsencrypt
       environment:
         - CN="fake.domain.com"

--- a/nginx/sites/default.conf
+++ b/nginx/sites/default.conf
@@ -6,8 +6,8 @@ server {
     # For https
     # listen 443 ssl default_server;
     # listen [::]:443 ssl default_server ipv6only=on;
-    # ssl_certificate /etc/nginx/ssl/default.crt;
-    # ssl_certificate_key /etc/nginx/ssl/default.key;
+    # ssl_certificate /etc/nginx/ssl/yourhost.tld-fullchain1.pem;
+    # ssl_certificate_key /etc/nginx/ssl/yourhost.tld-privkey1.pem;
 
     server_name localhost;
     root /var/www/public;


### PR DESCRIPTION
## Description
This fix makes certbot usable without having to figure out how things (could) work

Fixes: https://github.com/laradock/laradock/issues/3028

## Motivation and Context
certbot was never really implemented, there is a container for it, but no clear instructions on how to use it in eg. nginx
nginx also does not mount .well-known by default, which is needed for requesting certs via www

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
