### PR TITLE
fix mysql_native_password

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -12,6 +12,13 @@ ENV TZ ${TZ}
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && chown -R mysql:root /var/lib/mysql/
 
 COPY my.cnf /etc/mysql/conf.d/my.cnf
+COPY myold.cnf /etc/mysql/conf.d/myold.cnf
+
+RUN if [[ "${MYSQL_VERSION}" < "8.0" ]]; then \
+        mv /etc/mysql/conf.d/myold.cnf /etc/mysql/conf.d/my.cnf; \
+    else \
+        rm /etc/mysql/conf.d/myold.cnf; \
+    fi
 
 RUN chmod 0444 /etc/mysql/conf.d/my.cnf
 

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,5 +8,5 @@
 [mysqld]
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
-default-authentication-plugin=mysql_native_password
+mysql_native_password=on
 innodb_use_native_aio=0

--- a/mysql/myold.cnf
+++ b/mysql/myold.cnf
@@ -1,0 +1,12 @@
+# The MySQL  Client configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysql]
+
+[mysqld]
+sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+character-set-server=utf8
+default-authentication-plugin=mysql_native_password
+innodb_use_native_aio=0


### PR DESCRIPTION
## Description
Fix unknown variable 'default-authentication-plugin=mysql_native_password'.

## Motivation and Context
Recently my development environments stopped working when I downloaded the containers and updated the repository with git pull.
This change affects the latest version of mysql in laradock. There are no consequences on the databases.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
