### PR TITLE
Fix `mysql_native_password` on MySQL 8.4.0 (2024-04-30, LTS Release)

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -15,4 +15,10 @@ COPY my.cnf /etc/mysql/conf.d/my.cnf
 
 RUN chmod 0444 /etc/mysql/conf.d/my.cnf
 
+RUN if [ ${MYSQL_VERSION} > '8.4.0-0.000' ]; then \
+  echo 'mysql_native_password=on' >> /etc/mysql/conf.d/my.cnf \
+else \
+  echo 'default-authentication-plugin=mysql_native_password' >> /etc/mysql/conf.d/my.cnf \
+;fi
+
 EXPOSE 3306

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,5 +8,4 @@
 [mysqld]
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
-default-authentication-plugin=mysql_native_password
 innodb_use_native_aio=0


### PR DESCRIPTION
## Description
Closes #3518
>Important Change: The deprecated mysql_native_password authentication plugin is now disabled by default. It can be enabled by starting MySQL with the new --mysql-native-password=ON server option, or by adding mysql_native_password=ON to the [mysqld] section of your MySQL configuration file.

Fix unknown variable 'default-authentication-plugin=mysql_native_password'.


## Motivation and Context
>When using mysql latest version, mysql server wolud not working. If change version to 8.3, would be work successfully.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
