### PR TITLE
Update my.cnf

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,5 +8,5 @@
 [mysqld]
 sql-mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 character-set-server=utf8
-default-authentication-plugin=mysql_native_password
+mysql_native_password=ON
 innodb_use_native_aio=0


### PR DESCRIPTION
use`mysql_native_password=ON ` instead of deprecated `default-authentication-plugin=mysql_native_password` https://php.watch/articles/fix-php-mysql-84-mysql_native_password-not-loaded
