### PR TITLE
Fix error with 'mysql_native_password' option when attempting to bring up a mysql container

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -18,8 +18,8 @@ RUN chmod 0444 /etc/mysql/conf.d/my.cnf
 RUN version_gt() { \
   test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; \
   }; \
-  mysql_version_trimmed=$(echo "$MYSQL_VERSION" | grep -oE '^[0-9]+\.[0-9]+'); \
-  if version_gt "$mysql_version_trimmed" "8.3"; then \
+  MYSQL_VERSION=$(mysqld --version | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+"); \
+  if version_gt "$MYSQL_VERSION" "8.3"; then \
   echo 'mysql_native_password=on' >> /etc/mysql/conf.d/my.cnf ; \
   else \
   echo 'default-authentication-plugin=mysql_native_password' >> /etc/mysql/conf.d/my.cnf ; \

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -15,10 +15,14 @@ COPY my.cnf /etc/mysql/conf.d/my.cnf
 
 RUN chmod 0444 /etc/mysql/conf.d/my.cnf
 
-RUN if [ ${MYSQL_VERSION} > '8.4.0-0.000' ]; then \
-  echo 'mysql_native_password=on' >> /etc/mysql/conf.d/my.cnf \
-else \
-  echo 'default-authentication-plugin=mysql_native_password' >> /etc/mysql/conf.d/my.cnf \
-;fi
+RUN version_gt() { \
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; \
+  }; \
+  mysql_version_trimmed=$(echo "$MYSQL_VERSION" | grep -oE '^[0-9]+\.[0-9]+'); \
+  if version_gt "$mysql_version_trimmed" "8.3"; then \
+  echo 'mysql_native_password=on' >> /etc/mysql/conf.d/my.cnf ; \
+  else \
+  echo 'default-authentication-plugin=mysql_native_password' >> /etc/mysql/conf.d/my.cnf ; \
+  fi
 
 EXPOSE 3306


### PR DESCRIPTION
## Description
When MYSQL 8.4 was released it it no longer supports the `default-authentication-plugin=mysql_native_password` configuration, instead you need to specify `mysql_native_password=on` from MYSQL version 8.4 onwards.

This was attempted to be fixed in pull request #3521 but this broke it completely. There are a number of issues on this pull request;
- MYSQL_VERSION won't just be a number, it can be 'latest' (this is the default open in Laradock)
- To compare floats (in this case, version strings), it requires some funkyness which has been implemented, because the previous check didn't do that, it caused the script to also go to the true block no matter what the version of MySQL was
- Missing semi-colon on line 19 that caused the rest of the bash script to be echo'd to the file, so even if the if statement did work as expected the config file would still be wrong

This pull request implements logic into the Dockerfile for the MySQL container to check what version of MySQL is running and fixes this issue.

## Motivation and Context
This fixes the problem of the MySQL container not getting stood up no matter what version of MySQL you try to use.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
