### PR TITLE
Fix swoole

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -581,7 +581,7 @@ RUN set -eux; \
       elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
         echo '' | pecl -q install swoole-4.8.12; \
       elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ]; then \
-        echo '' | pecl -q install swoole-5.1.3; \
+        echo '' | pecl -q install swoole-5.1.2; \
       else \
         echo '' | pecl -q install swoole; \
       fi; \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -580,6 +580,8 @@ RUN set -eux; \
         echo '' | pecl -q install swoole-4.5.11; \
       elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]; then \
         echo '' | pecl -q install swoole-4.8.12; \
+      elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ]; then \
+        echo '' | pecl -q install swoole-5.1.3; \
       else \
         echo '' | pecl -q install swoole; \
       fi; \


### PR DESCRIPTION
## Description
```
0.404 + pecl -q install swoole
ERROR: `/tmp/pear/temp/swoole/configure --with-php-config=/usr/bin/php-config --enable-sockets=no \
    --enable-openssl=no --enable-mysqlnd=no --enable-swoole-curl=no --enable-cares=no --enable-brotli=yes \
    --enable-swoole-pgsql=no --with-swoole-odbc=no --with-swoole-oracle=no --enable-swoole-sqlite=no' failed
------
Error: Process completed with exit code 17.
```
https://pecl.php.net/package-info.php?package=swoole&version=6.0.0
- No longer supports Swoole\Coroutine\MySQL coroutine client.

- Closes #3538

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
