### PR TITLE
chore(jenkins): Update jdk and jenkins versions

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM openjdk:17-jdk-bullseye
 
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
@@ -36,11 +36,11 @@ COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groov
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.381}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.469}
 
 # jenkins.war checksum, download will be validated using it
-# 2.303.2
-ARG JENKINS_SHA=62ca5dcecbf176452d94d4438488662e223ab9594dccb564f065c63832a47302
+# 2.469
+ARG JENKINS_SHA=954b2759e2309151596e90bb5a88ddfd950d9397440403641bbefe5c3a2a016e
 
 
 # Can be used to customize where jenkins.war get downloaded from


### PR DESCRIPTION
## Description
I updated JDK and Jenkins versions.

## Motivation and Context
Jenkins no longer supports JDK 11.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
