### PR TITLE
Use MSSQL 2019 instead of 2017

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -618,16 +618,16 @@ services:
 
 ### MSSQL ################################################
     mssql:
-      restart: always
       build:
         context: ./mssql
+      user: root
       environment:
         - MSSQL_PID=Express
         - MSSQL_DATABASE=${MSSQL_DATABASE}
         - SA_PASSWORD=${MSSQL_PASSWORD}
         - ACCEPT_EULA=Y
       volumes:
-        - mssql:/var/opt/mssql
+        - mssql:/var/opt/mssql/data
       ports:
         - "${MSSQL_PORT}:1433"
       networks:

--- a/mssql/Dockerfile
+++ b/mssql/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+FROM mcr.microsoft.com/mssql/server:2019-latest
 
 ENV MSSQL_PID=Express
 ENV MSSQL_DATABASE=$MSSQL_DATABASE
 ENV ACCEPT_EULA=Y
-ENV SA_PASSWORD=$MSSQL_PASSWORD
+ENV MSSQL_SA_PASSWORD=$MSSQL_PASSWORD
 
 VOLUME /var/opt/mssql
 


### PR DESCRIPTION
## Description
This bumps the version of MSSQL from 2017 to 2019.

## Motivation and Context
Though usage of MSSQL with Laravel is quite rare compared to other types of DBs, some projects do use it and need at least 2019 version. Changes to the docker-compose.yml are required because without them container goes into infinite reboot with errors.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so). (nothing to update there really)
- [x] I enjoyed my time contributing and making developer's life easier :)
