### PR TITLE
Restrict to last working version of pecl-redis

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -308,6 +308,8 @@ RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
       pecl install -o -f redis-4.3.0; \
     elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ] ;}; then \
       pecl install -o -f redis-5.3.7; \
+    elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "2" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "3" ] ;}; then \
+      pecl install -o -f redis-6.0.2; \
     else \
       pecl install -o -f redis; \
     fi \


### PR DESCRIPTION
## Description

Restrict to last working version of `pecl-redis` for PHP7.2 and PHP7.3

## Motivation and Context
`pecl/redis requires PHP (version >= 7.4.0), installed version is 7.2.34`

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
