### PR TITLE
Fix openresty brotli library dependencies missing

### DIFF
--- a/openresty/Dockerfile
+++ b/openresty/Dockerfile
@@ -168,6 +168,8 @@ RUN apk add --no-cache --virtual .build-deps \
     && tar xzf nginx-dav-ext-module.tar.gz \
     && curl -fSL https://github.com/google/ngx_brotli/archive/master.tar.gz -o ngx_brotli.tar.gz \
     && tar xzf ngx_brotli.tar.gz \
+    && curl -fSL https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz -o ngx_brotli_deps.tar.gz \
+    && tar xzf ngx_brotli_deps.tar.gz -C ngx_brotli-master/deps/brotli --strip-components=1  \
     && curl -fSL https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/master.tar.gz -o ngx_http_substitutions_filter_module.tar.gz \
     && tar xzf ngx_http_substitutions_filter_module.tar.gz \
     && curl -fSL https://github.com/FRiCKLE/ngx_cache_purge/archive/master.tar.gz -o ngx_cache_purge.tar.gz \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add Brotli library's dependencies to the Dockerfile to fix the missing Brotli library dependencies bug.

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->

The currently installed Brotli is downloaded directly from GitHub; however, the deps directory included within it is empty. This means that additional steps are required to download the necessary dependencies separately. If these dependencies are not acquired, you will encounter an error stating "brotli is missing" during the image packaging process.

```
476.4 ./configure: error: Brotli library is missing from the /tmp/ngx_brotli-master/deps/brotli/c directory.
476.4
476.4 Please make sure that the git submodule has been checked out:
476.4
476.4     cd /tmp/ngx_brotli-master && git submodule update --init && cd /tmp/openresty-1.19.3.2/build/nginx-1.19.3
476.4
476.4 ERROR: failed to run command: sh ./configure --prefix=/usr/local/openresty/nginx \...
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix : added missing brotli library deps.


## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](http://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
