### PR TITLE
Fix MailDev docker-compose exposes the wrong port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1242,7 +1242,7 @@ services:
       restart: always
       build: ./maildev
       ports:
-        - "${MAILDEV_HTTP_PORT}:80"
+        - "${MAILDEV_HTTP_PORT}:1080"
         - "${MAILDEV_SMTP_PORT}:25"
       networks:
         - frontend


### PR DESCRIPTION
## Description
I altered the docker-compose.yml MailDev UI port to fix MailDev UI not beeing accessible from http://localhost:1080

## Motivation and Context
I was trying to run MailDev and was surprised when I couldn't access the UI through localhost. Upon reading the [documentation](https://github.com/maildev/maildev#user-content-docker-run), I found out the port that is used inside the container for the MailDev UI should be 1080 and not 80.

So I made the following change and was able to access it though localhost:

```yaml
ports:
- "${MAILDEV_HTTP_PORT}:80 -> 1080"
- "${MAILDEV_SMTP_PORT}:25"
```
<!--- What problem does it solve, or what feature does it add? -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix: changed maildev ui port 80 -> 1080.

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](https://laradock.io/contributing).
- [x] I've updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)