### PR TITLE
Fixed pecl redis, PHP <= 7.3 removed

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -308,6 +308,8 @@ RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
       pecl install -o -f redis-4.3.0; \
     elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ] ;}; then \
       pecl install -o -f redis-5.3.7; \
+    elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "2" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "3" ] ;}; then \
+      pecl install -o -f redis-6.0.2; \
     else \
       pecl install -o -f redis; \
     fi \

--- a/php-worker/Dockerfile
+++ b/php-worker/Dockerfile
@@ -380,6 +380,10 @@ RUN if [ ${INSTALL_REDIS} = true ]; then \
   # Install Redis Extension
   if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
   printf "\n" | pecl install -o -f redis-4.3.0; \
+  elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ] ;}; then \
+  printf "\n" | pecl install -o -f redis-5.3.7; \
+  elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "2" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "3" ] ;}; then \
+  printf "\n" | pecl install -o -f redis-6.0.2; \
   else \
   printf "\n" | pecl install -o -f redis; \
   fi; \


### PR DESCRIPTION
## Description
PECL Redis 6.1.0 removed PHP <= 7.3
https://pecl.php.net/package-info.php?package=redis&version=6.1.0

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](https://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
