### PR TITLE
Fix `edit this page` links

### DIFF
--- a/DOCUMENTATION/docusaurus.config.ts
+++ b/DOCUMENTATION/docusaurus.config.ts
@@ -39,7 +39,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/laradock/laradock/edit/master/DOCUMENTATION/',
         },
         // blog: {
         //   showReadingTime: true,


### PR DESCRIPTION
## Description
>clicking edit this page takes me to the docusaurus repo instead of the markdown file from the docs
>link should take me to the markdown file from the docs

## Motivation and Context
Closes #3576

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [Contribution Guide](https://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
