### PR TITLE
Update createdb.sql.example

### DIFF
--- a/mariadb/docker-entrypoint-initdb.d/createdb.sql.example
+++ b/mariadb/docker-entrypoint-initdb.d/createdb.sql.example
@@ -13,7 +13,7 @@
 ### if your $DATA_PATH_HOST/mariadb is exists and you do not want to delete it, you can run by manual execution:
 ###
 ###     docker-compose exec mariadb bash
-###     mysql -u root -p < /docker-entrypoint-initdb.d/createdb.sql
+###     mariadb -u root -p < /docker-entrypoint-initdb.d/createdb.sql
 ###
 
 #CREATE DATABASE IF NOT EXISTS `dev_db_1` COLLATE 'utf8_general_ci' ;


### PR DESCRIPTION
## Description
As specified in MariaDB docker documentation, since mariadb:11 (mariadb:latest) has no mysql executable or symlink. mariadb is the official command line executable.

## Motivation and Context
Run `mysql` on `mariadb` container returns "mysql: command not found"

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [] I've read the [Contribution Guide](https://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
