### PR TITLE
fix install phpredis for php7.2

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -306,7 +306,7 @@ RUN if [ ${INSTALL_PHPREDIS} = true ]; then \
     # Install Php Redis Extension
     if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]; then \
       pecl install -o -f redis-4.3.0; \
-    elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ] ;}; then \
+    elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ] && { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "2" ] ;}; then \
       pecl install -o -f redis-5.3.7; \
     else \
       pecl install -o -f redis; \


### PR DESCRIPTION
 => ERROR [php-fpm 21/82] RUN if [ true = true ]; then     if [ $(php -r "echo PHP_MAJOR_VER  17.2s
------
 > [php-fpm 21/82] RUN if [ true = true ]; then     if [ $(php -r "echo PHP_MAJOR_VERSION;") = "5" ]
; then       pecl install -o -f redis-4.3.0;     elif [ $(php -r "echo PHP_MAJOR_VERSION;") = "7" ]
&& { [ $(php -r "echo PHP_MINOR_VERSION;") = "0" ] || [ $(php -r "echo PHP_MINOR_VERSION;") = "1" ]
;}; then       pecl install -o -f redis-5.3.7;     else       pecl install -o -f redis;     fi     &
& rm -rf /tmp/pear     && docker-php-ext-enable redis ;fi:
4.276 warning: pecl/redis requires PHP (version >= 7.4.0), installed version is 7.2.34
5.209 downloading redis-6.1.0.tgz ...
5.209 Starting to download redis-6.1.0.tgz (373,740 bytes)