### PR TITLE
Fix for #3681

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -63,6 +63,8 @@ RUN set -xe; \
     if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
       groupmod --new-name laradock ubuntu; \
       usermod --login laradock ubuntu --move-home --home /home/laradock; \
+      groupmod -g ${PGID} laradock; \
+      usermod -u ${PUID} -g ${PGID} laradock; \
     else \
       groupadd -g ${PGID} laradock; \
       useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \


### PR DESCRIPTION
## Description
Fixes PUID and PGID env settings being ignored in workspace for PHP 8.1 and up.

## Motivation and Context
Fix for #3681 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've not read the [Contribution Guide](https://laradock.io/contributing) as it throws "Page Not Found"
- [x] I've not updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) as this is a minor fix for a minor bug. 
- [x] I enjoyed my time contributing and making developer's life easier :)
