### PR TITLE
Fix: cant use custom UID/GID with php8.1+

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -60,7 +60,7 @@ RUN set -xe; \
     fi; \
     apt-get update -yqq ${APT_GET_UPDATE_OPTIONS} && \
     pecl channel-update pecl.php.net && \
-    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
+    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ] && [ "${PUID}" = "1000" ]; then \
       groupmod --new-name laradock ubuntu; \
       usermod --login laradock ubuntu --move-home --home /home/laradock; \
     else \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -60,9 +60,17 @@ RUN set -xe; \
     fi; \
     apt-get update -yqq ${APT_GET_UPDATE_OPTIONS} && \
     pecl channel-update pecl.php.net && \
-    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ] && [ "${PUID}" = "1000" ]; then \
-      groupmod --new-name laradock ubuntu; \
-      usermod --login laradock ubuntu --move-home --home /home/laradock; \
+    if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
+      if [ "${PGID}" = "1000" ]; then \
+        groupmod --new-name laradock ubuntu; \
+      else \
+        groupadd -g ${PGID} laradock; \
+      fi; \
+      if [ "${PUID}" = "1000" ]; then \
+        usermod --login laradock ubuntu --move-home --home /home/laradock; \
+      else \
+        useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \
+      fi; \
     else \
       groupadd -g ${PGID} laradock; \
       useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -61,16 +61,8 @@ RUN set -xe; \
     apt-get update -yqq ${APT_GET_UPDATE_OPTIONS} && \
     pecl channel-update pecl.php.net && \
     if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
-      if [ "${PGID}" = "1000" ]; then \
-        groupmod --new-name laradock ubuntu; \
-      else \
-        groupadd -g ${PGID} laradock; \
-      fi; \
-      if [ "${PUID}" = "1000" ]; then \
-        usermod --login laradock ubuntu --move-home --home /home/laradock; \
-      else \
-        useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \
-      fi; \
+      groupmod --new-name laradock -g ${PGID} ubuntu; \
+      usermod --login laradock -u ${PUID} --move-home --home /home/laradock ubuntu; \
     else \
       groupadd -g ${PGID} laradock; \
       useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \


### PR DESCRIPTION
## Description
PHP version 8.1+ ignores PUID/PGID ENV variables.

These open issues seem to be related to this:
- https://github.com/laradock/laradock/issues/3681
- https://github.com/laradock/laradock/issues/3649

## Motivation and Context

1. PHP8.1+ Dockerfiles changed to be using noble instead of focal baseimage: (https://github.com/laradock/workspace/issues/72). Since these baseimages have ubuntu user (1000) already, it conflicted with laradock user (https://github.com/laradock/laradock/issues/3619)
2. Fix was needed so in these cases laradock user can gracefuly replace ubuntu and be UID 1000. It was implemented here https://github.com/laradock/laradock/pull/3621. 
3. However in PHP8.1+ the fix ignores PUID/PGID ENV variables and prevents laradock user getting UID other than 1000.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/contributing).
- [ ] I've updated the **documentation**. (refer to [this](https://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
