### PR TITLE
fix(workspace): apply PUID/PGID to laradock user on PHP 8.x builds Th…

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -63,6 +63,8 @@ RUN set -xe; \
     if [ $(php -r "echo PHP_MAJOR_VERSION;") = "8" ] && [ $(php -r "echo PHP_MINOR_VERSION;") != "0" ]; then \
       groupmod --new-name laradock -g ${PGID} ubuntu; \
       usermod --login laradock -u ${PUID} --move-home --home /home/laradock ubuntu; \
+      usermod -u ${PUID} laradock; \
+      groupmod -g ${PGID} laradock; \
     else \
       groupadd -g ${PGID} laradock; \
       useradd -l -u ${PUID} -g laradock -m laradock -G docker_env; \


### PR DESCRIPTION
## Problem
On PHP 8.x base images, the workspace Dockerfile renames the
pre-existing `ubuntu` user (uid=1000) to `laradock` instead of
creating a new one. The `PUID`/`PGID` build args were only applied
in the `else` branch (PHP < 8), so `WORKSPACE_PUID`/`WORKSPACE_PGID`
had no effect on PHP 8.x builds — the user always ended up with uid=1000.

## Fix
After renaming the user, apply `usermod -u ${PUID}` and
`groupmod -g ${PGID}` so the configured UID/GID are honoured
on PHP 8.x as well.

## Impact
Users whose host UID differs from 1000 (e.g. uid=1001) will now get
correct file ownership on shared volumes without needing workarounds.