### PR TITLE
feat: bump default ELK stack to 8.19.13

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1062,7 +1062,7 @@ GEARMAN_MYSQL_TABLE=gearman_queue
 
 ### ELK Stack #############################################
 
-ELK_VERSION=7.9.1
+ELK_VERSION=8.19.13
 
 ### Tarantool #############################################
 


### PR DESCRIPTION
## Description
Bumps the default `ELK_VERSION` from 7.9.1 (2020, EOL) to 8.19.13. Supersedes #3720, credit to @RYun601 for proposing it.

The compose config already sets `xpack.security.enabled=false` and transport ssl off, which are the ES 8 breaking defaults, so 8.x boots cleanly with no other changes.

**Verified locally with stock laradock config on 8.19.13:**
- elasticsearch: cluster health **green**
- kibana: `api/status` **available**
- logstash: pipeline **running**, test event ingested via TCP and searchable in ES (`logs-generic-default` data stream)

Only affects new setups: existing users keep their own `.env`, so zero breaking changes for current installs.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [x] Verified the full ELK stack boots and ingests on the new version.
- [x] I enjoyed my time contributing and making developer's life easier :)