### PR TITLE
chore: bump MSSQL from EOL 2017 to 2022

### DIFF
--- a/mssql/Dockerfile
+++ b/mssql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+FROM mcr.microsoft.com/mssql/server:2022-latest
 
 ENV MSSQL_PID=Express
 ENV MSSQL_DATABASE=$MSSQL_DATABASE


### PR DESCRIPTION
## Description
The `mssql` service pinned `mcr.microsoft.com/mssql/server:2017-latest-ubuntu` (Ubuntu 16.04 base, mainstream support long over). Bumps to `2022-latest`, the current GA release (2025 images are still preview/CTP).

Note: SQL Server 2022 requires **2GB RAM minimum** for the container.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).