### PR TITLE
chore: bump default Tomcat 8.5.43 -> 9.0 (EOL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -979,7 +979,7 @@ SONARQUBE_POSTGRES_PASSWORD=sonarPass
 
 ### TOMCAT ################################################
 
-TOMCAT_VERSION=8.5.43
+TOMCAT_VERSION=9.0
 TOMCAT_HOST_HTTP_PORT=8080
 
 ### CASSANDRA #############################################


### PR DESCRIPTION
## Description
Tomcat 8.5 reached EOL in March 2024. Bumps the default `TOMCAT_VERSION` to `9.0`.

9.0 is deliberately chosen over 10.x/11.x: it's the newest line that keeps the `javax.*` servlet namespace (Servlet 4.0), so it stays drop-in for existing user webapps. 10.x/11.x switch to `jakarta.*` and would break apps built for javax. laradock only runs the image (users bring their own WAR), so this is a safe default bump.

**Verified:** `tomcat:9.0` (9.0.120) starts cleanly.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).