### PR TITLE
chore: bump Traefik v2.2 -> v3.7

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:v2.2
+FROM traefik:v3.7
 
 LABEL maintainer="Luis Coutinho <luis@luiscoutinho.pt>"
 


### PR DESCRIPTION
## Description
Traefik v2.2 is long past EOL; v3 is the current line. laradock's static configuration (entrypoints, http->https redirection, ACME/Let's Encrypt httpchallenge, docker provider, accesslog) uses standard flags that all parse unchanged under v3, and the dynamic labels (`Host()` router rule, `basicauth` middleware, `api@internal`) remain valid in v3.

**Verified locally:** image builds; `traefik v3.7.7` starts with laradock's exact static flags and mounted docker socket, with no unknown-flag, config, or deprecation errors.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).