### PR TITLE
feat: add pgvector service (PostgreSQL + vector search)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -486,6 +486,17 @@ POSTGRES_PASSWORD=secret
 POSTGRES_PORT=5432
 POSTGRES_ENTRYPOINT_INITDB=./postgres/docker-entrypoint-initdb.d
 
+### PGVECTOR ##############################################
+
+# PostgreSQL with the pgvector extension (vector similarity search / AI, RAG).
+# Uses a separate port and data folder so it can run alongside `postgres`.
+PGVECTOR_VERSION=pg17
+PGVECTOR_PORT=5433
+PGVECTOR_DB=default
+PGVECTOR_USER=default
+PGVECTOR_PASSWORD=secret
+PGVECTOR_ENTRYPOINT_INITDB=./pgvector/docker-entrypoint-initdb.d
+
 ### POSTGRES-POSTGIS ######################################
 
 POSTGIS_VERSION=17-3.5

--- a/DOCUMENTATION/docs/usage.md
+++ b/DOCUMENTATION/docs/usage.md
@@ -1222,6 +1222,26 @@ Varnish sits behind NGINX as a caching reverse proxy. NGINX listens on 80/443, f
 **Master key** — `masterkey`.
 
 
+<a name="Use-pgvector"></a>
+### pgvector (PostgreSQL + vectors)
+
+[pgvector](https://github.com/pgvector/pgvector) is the PostgreSQL extension for vector similarity search, commonly used for AI/RAG features. This service runs a Postgres image with pgvector preinstalled, on its own port and data folder so it can run alongside the regular `postgres` service.
+
+1. Configure it in your `.env` (defaults shown):
+   ```dotenv
+   PGVECTOR_VERSION=pg17
+   PGVECTOR_PORT=5433
+   PGVECTOR_DB=default
+   PGVECTOR_USER=default
+   PGVECTOR_PASSWORD=secret
+   ```
+2. Start the container:
+   ```bash
+   docker-compose up -d pgvector
+   ```
+3. Connect on host port `5433`. The `vector` extension is enabled automatically in `PGVECTOR_DB` on first init (see `pgvector/docker-entrypoint-initdb.d/init.sql`).
+
+
 <a name="Use-Beanstalkd"></a>
 ### Beanstalkd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   meilisearch:
     driver: ${VOLUMES_DRIVER}
+  pgvector:
+    driver: ${VOLUMES_DRIVER}
   elasticsearch:
     driver: ${VOLUMES_DRIVER}
   mosquitto:
@@ -678,6 +680,22 @@ services:
         - POSTGRES_CONFLUENCE_PASSWORD=${CONFLUENCE_POSTGRES_PASSWORD}
       networks:
         - backend
+
+### pgvector (PostgreSQL + vector) #######################
+    pgvector:
+      image: pgvector/pgvector:${PGVECTOR_VERSION}
+      volumes:
+        - ${DATA_PATH_HOST}/pgvector:/var/lib/postgresql/data
+        - ${PGVECTOR_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
+      ports:
+        - "${PGVECTOR_PORT}:5432"
+      environment:
+        - POSTGRES_DB=${PGVECTOR_DB}
+        - POSTGRES_USER=${PGVECTOR_USER}
+        - POSTGRES_PASSWORD=${PGVECTOR_PASSWORD}
+      networks:
+        - backend
+
 ### pgbackups PostgreSQL #################################
     pgbackups:
       image: prodrigestivill/postgres-backup-local

--- a/pgvector/docker-entrypoint-initdb.d/init.sql
+++ b/pgvector/docker-entrypoint-initdb.d/init.sql
@@ -1,0 +1,2 @@
+-- Enable the pgvector extension in the default database on first init.
+CREATE EXTENSION IF NOT EXISTS vector;


### PR DESCRIPTION
## Description
Adds [pgvector](https://github.com/pgvector/pgvector), PostgreSQL with the vector-similarity extension, the backbone of AI/RAG features in modern PHP/Laravel apps.

- New `pgvector` service (image `pgvector/pgvector:${PGVECTOR_VERSION}`, default `pg17`)
- Runs on its **own port (5433)** and data folder so it coexists with the regular `postgres` service
- `pgvector/docker-entrypoint-initdb.d/init.sql` enables `CREATE EXTENSION vector` automatically on first init
- `.env.example` section, volume declaration, and usage docs

**Verified locally:** boots on `pg17`, the `vector` extension is auto-enabled (0.8.5), and a `vector(3)` table + nearest-neighbour (`<->`) query returns correctly.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).