### PR TITLE
feat: add Laravel Reverb service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -679,6 +679,12 @@ CADDY_CONFIG_PATH=./caddy/caddy
 
 LARAVEL_ECHO_SERVER_PORT=6001
 
+### LARAVEL REVERB ########################################
+
+# Laravel's first-party WebSocket server. Runs `php artisan reverb:start`
+# against your mounted application code.
+LARAVEL_REVERB_PORT=8080
+
 ### THUMBOR ###############################################
 
 THUMBOR_PORT=8000

--- a/DOCUMENTATION/docs/usage.md
+++ b/DOCUMENTATION/docs/usage.md
@@ -1222,6 +1222,20 @@ Varnish sits behind NGINX as a caching reverse proxy. NGINX listens on 80/443, f
 **Master key** — `masterkey`.
 
 
+<a name="Use-Laravel-Reverb"></a>
+### Laravel Reverb
+
+[Laravel Reverb](https://reverb.laravel.com) is Laravel's first-party WebSocket server (a modern replacement for the legacy `laravel-echo-server` / Soketi). This container runs `php artisan reverb:start` against your mounted application code.
+
+1. Install Reverb in your Laravel app (once): `php artisan install:broadcasting` and set `BROADCAST_CONNECTION=reverb` in your app `.env`.
+2. Point Reverb at `0.0.0.0` in your app `.env` so it is reachable from the host: `REVERB_HOST=0.0.0.0`, `REVERB_PORT=8080`.
+3. Start the container:
+   ```bash
+   docker-compose up -d laravel-reverb
+   ```
+4. The WebSocket server is available on host port `8080` (configurable via `LARAVEL_REVERB_PORT`).
+
+
 <a name="Use-Beanstalkd"></a>
 ### Beanstalkd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1384,6 +1384,24 @@ services:
         - frontend
         - backend
 
+### Laravel Reverb #######################################
+    laravel-reverb:
+      restart: always
+      build:
+        context: ./laravel-reverb
+        args:
+          - CHANGE_SOURCE=${CHANGE_SOURCE}
+          - LARADOCK_PHP_VERSION=${PHP_VERSION}
+      volumes:
+        - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}${APP_CODE_CONTAINER_FLAG}
+      ports:
+        - "${LARAVEL_REVERB_PORT}:8080"
+      depends_on:
+        - redis
+      networks:
+        - frontend
+        - backend
+
 ### Solr #################################################
     solr:
       restart: always

--- a/laravel-reverb/Dockerfile
+++ b/laravel-reverb/Dockerfile
@@ -1,0 +1,24 @@
+ARG LARADOCK_PHP_VERSION
+FROM php:${LARADOCK_PHP_VERSION}-cli-alpine
+
+LABEL maintainer="Laradock"
+
+# If you're in China, or need to change sources, set CHANGE_SOURCE to true in .env.
+ARG CHANGE_SOURCE=false
+RUN if [ ${CHANGE_SOURCE} = true ]; then \
+    sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories \
+;fi
+
+# Laravel Reverb runs an event loop and (optionally) scales over Redis; it needs
+# pcntl, posix and sockets, plus the redis extension for horizontal scaling.
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps $PHPIZE_DEPS linux-headers; \
+    docker-php-ext-install pcntl posix sockets; \
+    pecl install redis; \
+    docker-php-ext-enable redis; \
+    apk del .build-deps
+
+WORKDIR /var/www
+
+# Start the Reverb WebSocket server from the mounted Laravel application.
+CMD ["php", "artisan", "reverb:start", "--host=0.0.0.0", "--port=8080"]


### PR DESCRIPTION
## Description
Adds [Laravel Reverb](https://reverb.laravel.com), Laravel's **first-party WebSocket server** (GA 2024), the modern replacement for the now-legacy `laravel-echo-server` and the **abandoned Soketi** that laradock still ships.

- New `laravel-reverb` service, built from `php:${PHP_VERSION}-cli-alpine`
- Installs the `pcntl`, `posix`, `sockets` extensions Reverb's event loop needs, plus `redis` for horizontal scaling
- Mounts the app code and runs `php artisan reverb:start --host=0.0.0.0 --port=8080`
- `.env.example` section, compose block, usage docs

**Verified locally:** image builds on PHP 8.4.23; `pcntl`, `posix`, `sockets`, `redis` all loaded; the entrypoint correctly invokes `php artisan reverb:start`. Actually serving traffic requires a mounted Laravel app with Reverb installed, exactly like the existing `laravel-horizon` / `laravel-echo-server` services.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).