### PR TITLE
feat: add FrankenPHP service (Laravel Octane runtime)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,6 +310,14 @@ PHP_FPM_NEW_RELIC=false
 PHP_FPM_NEW_RELIC_KEY=0000
 PHP_FPM_NEW_RELIC_APP_NAME=app_name
 
+### FRANKENPHP ############################################
+
+# Modern Caddy-based PHP application server (Laravel Octane's recommended
+# runtime). Serves the app mounted at /app (Laravel docroot /app/public).
+FRANKENPHP_VERSION=1-php8
+FRANKENPHP_HTTP_PORT=8000
+FRANKENPHP_HTTPS_PORT=8443
+
 ### PHP_WORKER ############################################
 
 PHP_WORKER_INSTALL_BZ2=false

--- a/DOCUMENTATION/docs/usage.md
+++ b/DOCUMENTATION/docs/usage.md
@@ -1222,6 +1222,24 @@ Varnish sits behind NGINX as a caching reverse proxy. NGINX listens on 80/443, f
 **Master key** — `masterkey`.
 
 
+<a name="Use-FrankenPHP"></a>
+### FrankenPHP
+
+[FrankenPHP](https://frankenphp.dev) is a modern Caddy-based PHP application server and the recommended runtime for [Laravel Octane](https://laravel.com/docs/octane). It serves your app (mounted at `/app`, Laravel docroot `/app/public`) with automatic HTTPS, HTTP/3 and a worker mode.
+
+1. Configure it in your `.env` (defaults shown):
+   ```dotenv
+   FRANKENPHP_VERSION=1-php8
+   FRANKENPHP_HTTP_PORT=8000
+   FRANKENPHP_HTTPS_PORT=8443
+   ```
+2. Start the container:
+   ```bash
+   docker-compose up -d frankenphp
+   ```
+3. Your app is served on [https://localhost:8443](https://localhost:8443) (HTTP on `8000` auto-redirects to HTTPS). Add PHP extensions by editing `frankenphp/Dockerfile` (`install-php-extensions ...`). For Octane worker mode, follow the [Octane + FrankenPHP docs](https://laravel.com/docs/octane#frankenphp).
+
+
 <a name="Use-Beanstalkd"></a>
 ### Beanstalkd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -398,6 +398,23 @@ services:
         - "dockerhost:${DOCKER_HOST_IP}"
       networks:
         - backend
+
+### FrankenPHP ###########################################
+    frankenphp:
+      build:
+        context: ./frankenphp
+        args:
+          - FRANKENPHP_VERSION=${FRANKENPHP_VERSION}
+      volumes:
+        - ${APP_CODE_PATH_HOST}:/app${APP_CODE_CONTAINER_FLAG}
+      ports:
+        - "${FRANKENPHP_HTTP_PORT}:80"
+        - "${FRANKENPHP_HTTPS_PORT}:443"
+      extra_hosts:
+        - "dockerhost:${DOCKER_HOST_IP}"
+      networks:
+        - frontend
+        - backend
 ### Laravel Horizon ######################################
     laravel-horizon:
       restart: always

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -1,0 +1,19 @@
+ARG FRANKENPHP_VERSION=1-php8
+FROM dunglas/frankenphp:${FRANKENPHP_VERSION}
+
+LABEL maintainer="Laradock"
+
+# FrankenPHP ships mlocati's install-php-extensions helper. Install the
+# extensions a typical Laravel app needs; add more here as required.
+RUN install-php-extensions \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    intl \
+    zip \
+    gd \
+    bcmath \
+    pcntl \
+    opcache
+
+WORKDIR /app


### PR DESCRIPTION
## Description
Adds [FrankenPHP](https://frankenphp.dev), a modern Caddy-based PHP application server and the **recommended runtime for Laravel Octane** (worker mode, automatic HTTPS, HTTP/3). laradock has `caddy` but not FrankenPHP.

- New `frankenphp` service built from `dunglas/frankenphp:${FRANKENPHP_VERSION}` (default `1-php8`)
- Installs common Laravel extensions (pdo_mysql, pdo_pgsql, redis, intl, gd, bcmath, zip, pcntl, opcache) via the bundled `install-php-extensions`
- Mounts the app at `/app`, serves `/app/public`; configurable HTTP/HTTPS ports (8000/8443)
- `.env.example` section, compose block, usage docs

**Verified locally:** image builds (FrankenPHP 1.12.4 / PHP 8.5.8 / Caddy 2.11.4); all target extensions load; and it **serves executed PHP end-to-end over HTTPS** (returned `PHP_VERSION` from a mounted `public/index.php`).

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).