### PR TITLE
feat: add RoadRunner service (Laravel Octane driver)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,6 +310,13 @@ PHP_FPM_NEW_RELIC=false
 PHP_FPM_NEW_RELIC_KEY=0000
 PHP_FPM_NEW_RELIC_APP_NAME=app_name
 
+### ROADRUNNER ############################################
+
+# High-performance Go-based PHP application server (a Laravel Octane
+# driver). Serves the mounted app via its .rr.yaml.
+ROADRUNNER_VERSION=2025.1.15
+ROADRUNNER_HTTP_PORT=8090
+
 ### PHP_WORKER ############################################
 
 PHP_WORKER_INSTALL_BZ2=false

--- a/DOCUMENTATION/docs/usage.md
+++ b/DOCUMENTATION/docs/usage.md
@@ -1222,6 +1222,24 @@ Varnish sits behind NGINX as a caching reverse proxy. NGINX listens on 80/443, f
 **Master key** — `masterkey`.
 
 
+<a name="Use-RoadRunner"></a>
+### RoadRunner
+
+[RoadRunner](https://roadrunner.dev) is a high-performance Go-based PHP application server and a [Laravel Octane](https://laravel.com/docs/octane) driver. This container ships the `rr` binary on top of a PHP-CLI image and serves your mounted app via its `.rr.yaml`.
+
+1. In your Laravel app install Octane with the RoadRunner driver: `composer require laravel/octane spiral/roadrunner-cli` then `php artisan octane:install --server=roadrunner` (generates `.rr.yaml`). Set the HTTP address to `0.0.0.0:8080` in `.rr.yaml`.
+2. Configure it in your `.env` (defaults shown):
+   ```dotenv
+   ROADRUNNER_VERSION=2025.1.15
+   ROADRUNNER_HTTP_PORT=8090
+   ```
+3. Start the container:
+   ```bash
+   docker-compose up -d roadrunner
+   ```
+4. Your app is served on host port `8090` (configurable via `ROADRUNNER_HTTP_PORT`).
+
+
 <a name="Use-Beanstalkd"></a>
 ### Beanstalkd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -398,6 +398,24 @@ services:
         - "dockerhost:${DOCKER_HOST_IP}"
       networks:
         - backend
+
+### RoadRunner ###########################################
+    roadrunner:
+      build:
+        context: ./roadrunner
+        args:
+          - CHANGE_SOURCE=${CHANGE_SOURCE}
+          - LARADOCK_PHP_VERSION=${PHP_VERSION}
+          - ROADRUNNER_VERSION=${ROADRUNNER_VERSION}
+      volumes:
+        - ${APP_CODE_PATH_HOST}:${APP_CODE_PATH_CONTAINER}${APP_CODE_CONTAINER_FLAG}
+      ports:
+        - "${ROADRUNNER_HTTP_PORT}:8080"
+      extra_hosts:
+        - "dockerhost:${DOCKER_HOST_IP}"
+      networks:
+        - frontend
+        - backend
 ### Laravel Horizon ######################################
     laravel-horizon:
       restart: always

--- a/roadrunner/Dockerfile
+++ b/roadrunner/Dockerfile
@@ -1,0 +1,27 @@
+ARG ROADRUNNER_VERSION=2025.1.15
+ARG LARADOCK_PHP_VERSION=8.4
+
+# Pull the rr binary from the official RoadRunner image.
+FROM ghcr.io/roadrunner-server/roadrunner:${ROADRUNNER_VERSION} AS roadrunner
+
+FROM php:${LARADOCK_PHP_VERSION}-cli-alpine
+
+LABEL maintainer="Laradock"
+
+ARG CHANGE_SOURCE=false
+RUN if [ ${CHANGE_SOURCE} = true ]; then \
+    sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/' /etc/apk/repositories \
+;fi
+
+COPY --from=roadrunner /usr/bin/rr /usr/local/bin/rr
+
+# RoadRunner's PHP workers use sockets; opcache keeps them fast.
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps $PHPIZE_DEPS linux-headers; \
+    docker-php-ext-install sockets opcache; \
+    apk del .build-deps
+
+WORKDIR /var/www
+
+# Serves the mounted Laravel app via its .rr.yaml (e.g. Laravel Octane).
+CMD ["rr", "serve"]


### PR DESCRIPTION
## Description
Adds [RoadRunner](https://roadrunner.dev), a high-performance Go-based PHP application server and a **Laravel Octane** driver.

- New `roadrunner` service: copies the `rr` binary from `ghcr.io/roadrunner-server/roadrunner:${ROADRUNNER_VERSION}` (default `2025.1.15`) onto `php:${PHP_VERSION}-cli-alpine`
- Installs the `sockets` extension RoadRunner workers need
- Mounts the app and runs `rr serve` against its `.rr.yaml`
- `.env.example` section, compose block, usage docs

**Verified locally:** image builds; `rr version 2025.1.15`; PHP 8.4.23; `sockets` loaded; `rr serve` present. Actually serving requires a mounted Laravel app with a `.rr.yaml` (Octane), like the other app-runtime services.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).