### PR TITLE
feat: add Flowise service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -937,6 +937,11 @@ MOSQUITTO_PORT=9001
 
 COUCHDB_PORT=5984
 
+### FLOWISE ###############################################
+
+FLOWISE_VERSION=latest
+FLOWISE_HOST_PORT=3020
+
 ### Manticore Search ######################################
 
 MANTICORE_CONFIG_PATH=./manticore/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   memcached:
     driver: ${VOLUMES_DRIVER}
+  flowise:
+    driver: ${VOLUMES_DRIVER}
   redis:
     driver: ${VOLUMES_DRIVER}
   neo4j:
@@ -824,6 +826,18 @@ services:
       ports:
         - "${SSDB_PORT}:8888"
       networks:
+        - backend
+
+### Flowise ##############################################
+    flowise:
+      restart: always
+      image: flowiseai/flowise:${FLOWISE_VERSION}
+      volumes:
+        - flowise:/root/.flowise
+      ports:
+        - "${FLOWISE_HOST_PORT}:3000"
+      networks:
+        - frontend
         - backend
 
 ### ZooKeeper ############################################


### PR DESCRIPTION
## Description

Adds [Flowise](https://flowiseai.com/) as a Laradock service. Flowise is a visual, low-code builder for LLM apps and AI agents. It runs as a plain upstream image (`flowiseai/flowise`), so it is wired up like the `meilisearch` service (no Dockerfile / build step).

What was added:
- `docker-compose.yml`: a `flowise` service block (inserted before ZooKeeper) plus a `flowise` named volume.
- `.env.example`: a `### FLOWISE` section with `FLOWISE_VERSION=latest` and `FLOWISE_HOST_PORT=3020`.

Service details:
- Image `flowiseai/flowise:${FLOWISE_VERSION}` (default `latest`).
- Container port `3000` mapped to host `${FLOWISE_HOST_PORT}` (default `3020`, chosen to avoid collisions with existing Laradock defaults).
- Named volume `flowise` mounted at `/root/.flowise` so the SQLite DB, encryption keys, uploads, and storage persist across restarts.
- Attached to the `frontend` and `backend` networks.

## Motivation and Context

PHP / Laravel developers can use Flowise to prototype agent, chatbot, and RAG flows in a drag-and-drop UI, then call the resulting flow from any Laravel app over plain HTTP. The AI orchestration lives outside PHP and the app just consumes an endpoint, which fits how most teams add LLM features to an existing Laravel stack.

## Verification

Boot-tested with plain `docker run` using the same volume and port mapping as the compose block:

```
docker run -d --name flowise_boottest -p 3020:3000 -v flowise_boottest:/root/.flowise flowiseai/flowise:latest
curl -s -o /dev/null -w '%{http_code}' http://localhost:3020/api/v1/ping   # -> 200 (body: "pong")
curl -s -o /dev/null -w '%{http_code}' http://localhost:3020/              # -> 200
```

- Confirmed the image default entrypoint is `["flowise","start"]`.
- Confirmed data persists under `/root/.flowise` (`database.sqlite`, `encryption.key`, `storage/`, `uploads/`).
- Ran on `arm64` locally; the image is multi-arch so amd64 CI is unaffected.
- Container and volume were removed after the test.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [] I've updated the **documentation**. Docs (usage.md and the Supported Services table) are handled separately; the usage section text is provided below for a maintainer to drop in.
- [x] I enjoyed my time contributing and making developer's life easier :)

---

Suggested `DOCUMENTATION/docs/usage.md` section:

> <a name="Use-Flowise"></a>
> ### Flowise
>
> Flowise is a visual, low-code builder for LLM apps and AI agents. Use it to prototype agent, chatbot, and RAG flows in a drag-and-drop UI, then call them from your Laravel app over HTTP.
>
> 1. Start the container:
>    ```bash
>    docker-compose up -d flowise
>    ```
> 2. Open the builder at `http://localhost:3020`. The REST API is under the same host (health check: `http://localhost:3020/api/v1/ping` returns `pong`). Change the host port with `FLOWISE_HOST_PORT` in your `.env`.