### PR TITLE
feat: add Chroma vector database service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1015,6 +1015,13 @@ CASSANDRA_DATACENTER=dc1
 # Rack name for the cluster. Ignored in SimpleSnitch endpoint snitch. Default: rack1.
 CASSANDRA_RACK=rack1
 
+### CHROMA ################################################
+
+# Chroma (vector database) image version. See tags at https://hub.docker.com/r/chromadb/chroma
+CHROMA_VERSION=latest
+# Host port mapped to the Chroma HTTP API (container port 8000)
+CHROMA_HOST_PORT=8001
+
 ### GEARMAN ###############################################
 
 # Gearman version to use. See available tags at https://hub.docker.com/r/artefactual/gearmand

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   minio:
     driver: ${VOLUMES_DRIVER}
+  chroma:
+    driver: ${VOLUMES_DRIVER}
   rethinkdb:
     driver: ${VOLUMES_DRIVER}
   phpmyadmin:
@@ -868,6 +870,17 @@ services:
       depends_on:
         - php-fpm
       networks:
+        - backend
+
+### Chroma ###############################################
+    chroma:
+      image: chromadb/chroma:${CHROMA_VERSION}
+      volumes:
+        - chroma:/data
+      ports:
+        - "${CHROMA_HOST_PORT}:8000"
+      networks:
+        - frontend
         - backend
 
 ### Beanstalkd ###########################################


### PR DESCRIPTION
## Description

Adds **Chroma** (`chromadb/chroma`), a lightweight open-source vector database with a simple HTTP API, as an optional laradock service.

- Image-only service (no build step), referenced directly in `docker-compose.yml` like the `meilisearch` service.
- Version pinned via `CHROMA_VERSION` (default `latest`).
- Host port `CHROMA_HOST_PORT` (default `8001`) mapped to the container's port `8000`, picked to avoid collisions with common laradock defaults.
- Named volume `chroma` mounted at `/data` (the `persist_path` used by current 1.x tags) for durable storage across restarts.
- Attached to the `frontend` and `backend` networks.

Files changed: `docker-compose.yml` (service block + named volume) and `.env.example` (new `### CHROMA` section). No existing service was modified.

## Motivation and Context

Chroma is one of the most popular quick-start vector databases for embeddings and RAG prototypes. It exposes a plain REST API, so a PHP app running in the workspace can store and query vector embeddings over HTTP without any extra client tooling or a managed cloud service. This gives laradock users a batteries-included local vector store alongside the existing search and data services.

## Verification

Boot-tested with plain `docker run` using the same config as the compose block (arm64 host, multi-arch image, chroma 1.4.4):

```
docker run -d -p 8001:8000 -v chroma:/data chromadb/chroma:latest
curl http://localhost:8001/api/v2/heartbeat
# -> {"nanosecond heartbeat":1783628990929992133}
```

- The v2 heartbeat returns JSON as expected, and the container writes `chroma.sqlite3` to `/data`, confirming the persist path for this tag.
- The v1 API is deprecated on this tag (`/api/v1/heartbeat` returns an "Unimplemented, please use /v2" error), so the documented health check is `/api/v2/heartbeat`.
- `docker compose config` resolves the `chroma` service (ports `8001:8000`, volume `chroma` to `/data`, `frontend` + `backend` networks) and declares the `chroma` named volume.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [] I've updated the **documentation**. The `usage.md` section and the Supported Services table entry are being handled separately.
- [x] I enjoyed my time contributing and making developer's life easier :)
