### PR TITLE
feat: add Weaviate service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -977,6 +977,11 @@ SONARQUBE_POSTGRES_DB=sonar
 SONARQUBE_POSTGRES_USER=sonar
 SONARQUBE_POSTGRES_PASSWORD=sonarPass
 
+### WEAVIATE ##############################################
+
+WEAVIATE_VERSION=1.38.2
+WEAVIATE_HOST_PORT=8085
+
 ### TOMCAT ################################################
 
 TOMCAT_VERSION=8.5.43

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   mariadb:
     driver: ${VOLUMES_DRIVER}
+  weaviate:
+    driver: ${VOLUMES_DRIVER}
   mongo:
     driver: ${VOLUMES_DRIVER}
   minio:
@@ -855,6 +857,25 @@ services:
         - MEM_GB=${AEROSPIKE_MEM_GB}
         - NAMESPACE=${AEROSPIKE_NAMESPACE}
       networks:
+        - backend
+
+### Weaviate #############################################
+    weaviate:
+      image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_VERSION}
+      command: --host 0.0.0.0 --port 8080 --scheme http
+      volumes:
+        - weaviate:/var/lib/weaviate
+      ports:
+        - "${WEAVIATE_HOST_PORT}:8080"
+      environment:
+        - PERSISTENCE_DATA_PATH=/var/lib/weaviate
+        - DEFAULT_VECTORIZER_MODULE=none
+        - ENABLE_MODULES=
+        - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true
+        - QUERY_DEFAULTS_LIMIT=25
+        - CLUSTER_HOSTNAME=node1
+      networks:
+        - frontend
         - backend
 
 ### Memcached ############################################


### PR DESCRIPTION
## Description

Adds **Weaviate**, a popular open-source vector database with REST and GraphQL APIs, as an optional Laradock service. Fully additive: no existing service is modified.

- New `weaviate` service in `docker-compose.yml` using the official `cr.weaviate.io/semitechnologies/weaviate` image, pinned via `WEAVIATE_VERSION` (default `1.38.2`).
- Container port `8080` mapped to host `WEAVIATE_HOST_PORT` (default `8085`, picked to avoid clashing with common Laradock defaults).
- Data persisted to a named `weaviate` volume at `/var/lib/weaviate`.
- Boots with `DEFAULT_VECTORIZER_MODULE=none`, `ENABLE_MODULES=` (empty), `AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true`, `QUERY_DEFAULTS_LIMIT=25`, `CLUSTER_HOSTNAME=node1`, and command `--host 0.0.0.0 --port 8080 --scheme http`.
- New env vars in `.env.example`: `WEAVIATE_VERSION`, `WEAVIATE_HOST_PORT`.

Usage:

```bash
docker-compose up -d weaviate
```

Weaviate is then reachable at `http://localhost:8085` (REST + GraphQL). Readiness endpoint: `GET /v1/.well-known/ready`.

## Motivation and Context

Vector databases are now a core building block for embeddings, semantic search, and RAG. PHP developers building AI features want a local Weaviate they can hit over plain HTTP from their app without leaving the Laradock stack. This adds one, with anonymous access on and no vectorizer module so it runs out of the box.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Verification

Booted the pinned image with the same env vars, command, and volume mount the compose block uses, then curled the readiness endpoint from the host:

```
$ curl -s -o /dev/null -w "%{http_code}" http://localhost:8085/v1/.well-known/ready
200
```

`/v1/meta` reported `version: 1.38.2` and `/v1/.well-known/live` also returned `200`. `docker compose config` validates the full stack with the new service. The test container and temp data dir were removed afterward.

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [] I've updated the **documentation**. (usage doc + Supported Services table handled separately).
- [x] I enjoyed my time contributing and making developer's life easier :)
