### PR TITLE
feat: add Qdrant service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -960,6 +960,12 @@ SWAGGER_EDITOR_PORT=5151
 SWAGGER_API_URL=http://generator.swagger.io/api/swagger.json
 SWAGGER_UI_PORT=5555
 
+### QDRANT ################################################
+
+QDRANT_VERSION=latest
+QDRANT_HOST_PORT=6333
+QDRANT_GRPC_PORT=6334
+
 ### SONARQUBE #############################################
 
 ## docker-compose up -d sonarqube

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   neo4j:
     driver: ${VOLUMES_DRIVER}
+  qdrant:
+    driver: ${VOLUMES_DRIVER}
   mariadb:
     driver: ${VOLUMES_DRIVER}
   mongo:
@@ -836,6 +838,18 @@ services:
       ports:
         - "${ZOOKEEPER_PORT}:2181"
       networks:
+        - backend
+
+### Qdrant ###############################################
+    qdrant:
+      image: qdrant/qdrant:${QDRANT_VERSION}
+      volumes:
+        - qdrant:/qdrant/storage
+      ports:
+        - "${QDRANT_HOST_PORT}:6333"
+        - "${QDRANT_GRPC_PORT}:6334"
+      networks:
+        - frontend
         - backend
 
 ### Aerospike ############################################


### PR DESCRIPTION
## Description

Adds **Qdrant**, the most popular standalone open-source vector database, as a new Laradock service.

The service is image-only (`qdrant/qdrant`), modelled on the existing `meilisearch` service:

- Image and version parameterised via `QDRANT_VERSION` (default `latest`).
- REST API on host port `QDRANT_HOST_PORT` (default `6333`) and gRPC API on `QDRANT_GRPC_PORT` (default `6334`).
- A named `qdrant` volume mounted at `/qdrant/storage` for persistence.
- Joined to the `frontend` and `backend` networks.

Files touched (additive only, no existing service changed):

- `docker-compose.yml`: new `qdrant` service block and a `qdrant` named volume.
- `.env.example`: new `### QDRANT` section with the three variables above.

## Motivation and Context

PHP developers increasingly build semantic search and RAG (retrieval-augmented generation) features and need somewhere to store and query vector embeddings. Qdrant is the go-to standalone vector database for this and speaks a simple HTTP REST API, so it is easy to call from any PHP HTTP client. Having it in Laradock lets developers spin it up next to their app with a single `docker-compose up -d qdrant`.

## Verification

Booted the container with the same configuration the compose block uses (named volume mounted at `/qdrant/storage`, ports mapped) and queried the REST API from the host:

- `GET /healthz` -> `200` `healthz check passed`
- `GET /readyz` -> `200` `all shards are ready`
- `GET /` -> `200` `{"title":"qdrant - vector search engine","version":"1.18.2",...}`
- `GET /collections` -> `200` `{"result":{"collections":[]},"status":"ok"}`

The gRPC API was confirmed listening on `6334` in the container logs. `docker compose config` renders the service and volume correctly. The image is multi-arch (verified on arm64; CI is amd64). Test container and volume were removed afterwards.

## Types of Changes

- [] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:

- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [] I've updated the **documentation**. (The `usage.md` and Supported Services table entries are provided below and can be added in a follow-up so they land in one place.)
- [x] I enjoyed my time contributing and making developer's life easier :)

---

### Docs to add (usage.md)

```markdown
<a name="Use-Qdrant"></a>
### Qdrant

[Qdrant](https://qdrant.tech) is a high-performance open-source vector database. PHP developers use it to store and query embeddings for semantic search and RAG (retrieval-augmented generation) features over a simple REST API.

1. Start the container:

```bash
docker-compose up -d qdrant
```

2. The REST API is available on `http://localhost:6333` (health check at `/healthz`, web dashboard at `/dashboard`) and the gRPC API on `6334`. Change the host ports with `QDRANT_HOST_PORT` and `QDRANT_GRPC_PORT`, and pin the image with `QDRANT_VERSION` in your `.env`.
```

### Supported Services table entry (category: Vector Databases)

`[Qdrant](https://qdrant.tech)`
