### PR TITLE
feat: add Prometheus service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1087,6 +1087,11 @@ SOKETI_METRICS_SERVER_PORT=9601
 ONEDEV_HTTP_PORT=6610
 ONEDEV_SSH_PORT=6611
 
+### PROMETHEUS ############################################
+
+PROMETHEUS_VERSION=v3.13.0
+PROMETHEUS_HOST_PORT=9091
+
 ### Keycloak ##############################################
 
 KEYCLOAK_VERSION=latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   graylog:
     driver: ${VOLUMES_DRIVER}
+  prometheus:
+    driver: ${VOLUMES_DRIVER}
   docker-in-docker:
     driver: ${VOLUMES_DRIVER}
 
@@ -1067,6 +1069,19 @@ services:
         - "${ADM_PORT}:8080"
       # depends_on:
       #   - php-fpm
+      networks:
+        - frontend
+        - backend
+
+### Prometheus ###########################################
+    prometheus:
+      restart: always
+      image: prom/prometheus:${PROMETHEUS_VERSION}
+      volumes:
+        - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+        - prometheus:/prometheus
+      ports:
+        - "${PROMETHEUS_HOST_PORT}:9090"
       networks:
         - frontend
         - backend

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+# Minimal Prometheus configuration for Laradock.
+# Prometheus scrapes itself so you have data to explore out of the box.
+# Add more scrape jobs (php-fpm exporter, node-exporter, mysqld-exporter, etc.)
+# under scrape_configs as your stack grows.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Description

Adds **Prometheus**, the standard metrics and monitoring system, as a new Laradock service (image `prom/prometheus`).

Laradock already ships Grafana but had no Prometheus, which is the usual Grafana data source. This service gives users a ready time-series backend out of the box.

What was added:
- `docker-compose.yml`: a `prometheus` service block (before the pgAdmin block) plus a `prometheus` named volume.
- `.env.example`: a `PROMETHEUS` section with `PROMETHEUS_VERSION` (default `v3.13.0`) and `PROMETHEUS_HOST_PORT` (default `9091`).
- `prometheus/prometheus.yml`: a minimal config with a self-scrape job, mounted read-only at `/etc/prometheus/prometheus.yml`.

Configuration highlights:
- Container port `9090` mapped to host `PROMETHEUS_HOST_PORT` (default `9091`) to avoid colliding with common Laradock defaults.
- Named volume `prometheus` mounted at `/prometheus` for TSDB persistence.
- Attached to the `frontend` and `backend` networks so Grafana can use it as a data source and it can scrape backend services.

This change is fully additive. No existing service was modified or removed.

## Motivation and Context

For PHP developers, Prometheus provides a time-series backend to scrape application, queue, and infrastructure exporters (php-fpm, node-exporter, mysqld-exporter, etc.) and to power Grafana dashboards, all inside the existing Laradock stack. It closes the obvious gap of shipping Grafana without its most common data source.

Usage (proposed docs section, for the documentation site):

> ### Prometheus
>
> Prometheus is an open-source metrics and monitoring system with a time-series database and a powerful query language (PromQL). It is the most common data source for Grafana, so it pairs naturally with Laradock's existing Grafana service.
>
> 1. Start the container:
>    ```bash
>    docker-compose up -d prometheus
>    ```
> 2. Open the Prometheus web UI at `http://localhost:9091` (change the host port with `PROMETHEUS_HOST_PORT`). Health check: `http://localhost:9091/-/healthy`. Edit `prometheus/prometheus.yml` to add scrape targets, then restart the container.

## Verification

Booted `prom/prometheus:v3.13.0` with the config and volume mounted, host `9091` mapped to container `9090`:
- `curl http://localhost:9091/-/healthy` returned HTTP 200 `Prometheus Server is Healthy.`
- `curl http://localhost:9091/-/ready` returned HTTP 200 `Prometheus Server is Ready.`
- Buildinfo reported version `3.13.0`.
- The self-scrape `prometheus` target (`localhost:9090`) was active, confirming the mounted `prometheus.yml` loaded.

`docker compose config` also renders the service correctly (image, ports `9091:9090`, read-only config bind mount, named volume, both networks). Container and volume were removed after testing.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [ ] I've updated the **documentation**. (The usage.md section and Supported Services table entry are provided above and handled via the docs flow.)
- [x] I enjoyed my time contributing and making developer's life easier :)
