### PR TITLE
feat: add LocalAI service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -919,6 +919,11 @@ MAILU_WEBMAIL=rainloop
 # Dav server implementation (value: radicale, none)
 MAILU_WEBDAV=radicale
 
+### LOCALAI ###############################################
+
+LOCALAI_VERSION=latest
+LOCALAI_HOST_PORT=8088
+
 ### TRAEFIK ###############################################
 
 TRAEFIK_HOST_HTTP_PORT=80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   percona:
     driver: ${VOLUMES_DRIVER}
+  localai:
+    driver: ${VOLUMES_DRIVER}
   mssql:
     driver: ${VOLUMES_DRIVER}
   postgres:
@@ -751,6 +753,17 @@ services:
         - ${DATA_PATH_HOST}/mongo:/data/db
         - ${DATA_PATH_HOST}/mongo_config:/data/configdb
       networks:
+        - backend
+
+### LocalAI ##############################################
+    localai:
+      image: localai/localai:${LOCALAI_VERSION}
+      volumes:
+        - localai:/models
+      ports:
+        - "${LOCALAI_HOST_PORT}:8080"
+      networks:
+        - frontend
         - backend
 
 ### RethinkDB ############################################


### PR DESCRIPTION
## Description

Adds **LocalAI** as a new, image-only service. LocalAI is a free, self-hosted, drop-in replacement for the OpenAI REST API. It runs LLMs, embeddings, and image generation locally, with no GPU required and no API keys.

Changes are additive only, no existing service was modified:
- `docker-compose.yml`: new `localai` service (`image: localai/localai:${LOCALAI_VERSION}`), host port `${LOCALAI_HOST_PORT}` mapped to container `8080`, a named `localai` volume mounted at `/models`, attached to the `frontend` and `backend` networks. Also registers the `localai` named volume.
- `.env.example`: new `### LOCALAI` section with `LOCALAI_VERSION=latest` and `LOCALAI_HOST_PORT=8088`.

## Motivation and Context

PHP developers building AI features can point openai-php, Prism, or any OpenAI-compatible client at `http://localai:8080/v1` instead of `api.openai.com`. This enables fully local development and testing at zero per-token cost, with no data leaving the machine and no external dependency while developing.

## Verification

Boot-tested with plain `docker run`, mirroring the compose block (host port 8088 to container 8080, named volume mounted at `/models`):

- `docker pull localai/localai:latest` succeeded natively on arm64 (1.05GB), so no `--platform` override is needed. The image is multi-arch and CI runs amd64.
- `GET http://localhost:8088/readyz` returned `HTTP 200`.
- `GET http://localhost:8088/v1/models` (the OpenAI-compatible endpoint) returned `HTTP 200` with `{"object":"list","data":[]}`.
- No model was downloaded (kept the test light per the heavy-image guidance). The container and test volume were removed afterward.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the [Contribution Guide](https://laradock.io/docs/contributing).
- [ ] I've updated the **documentation**. The `usage.md` section and the Supported Services table entry are provided below and are being added separately, so the docs site and tables are intentionally left untouched in this PR.
- [x] I enjoyed my time contributing and making developer's life easier :)

---

### Suggested docs (added separately)

Proposed `DOCUMENTATION/docs/usage.md` section:

```markdown
<a name="Use-LocalAI"></a>
### LocalAI

[LocalAI](https://localai.io/) is a free, self-hosted, drop-in replacement for the OpenAI REST API. It runs LLMs, embeddings, and image generation on your own hardware, so PHP developers can point openai-php, Prism, or any OpenAI client at it instead of OpenAI, with no API keys and no data leaving the machine.

1. Start the container:
   ```bash
   docker-compose up -d localai
   ```
2. The API listens on [http://localhost:8088](http://localhost:8088). Check readiness with `curl http://localhost:8088/readyz` and list installed models with `curl http://localhost:8088/v1/models` (empty until you install one). Models persist in the `localai` volume mounted at `/models`. From your app container, use the base URL `http://localai:8080/v1` and any placeholder API key.
```

Proposed Supported Services table entry (new category **AI / LLM**):

```
| **AI / LLM**              | LocalAI                                                                  |
```
