### PR TITLE
feat: add Ollama service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -857,6 +857,11 @@ DOCKER_REGISTRY_PORT=5000
 DOCKER_REGISTRY_USE_SSL=0
 DOCKER_REGISTRY_BROWSE_ONLY=false
 
+### OLLAMA ################################################
+
+OLLAMA_VERSION=latest
+OLLAMA_HOST_PORT=11434
+
 ### MAILU #################################################
 
 MAILU_VERSION=latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ networks:
 volumes:
   mysql:
     driver: ${VOLUMES_DRIVER}
+  ollama:
+    driver: ${VOLUMES_DRIVER}
   percona:
     driver: ${VOLUMES_DRIVER}
   mssql:
@@ -736,6 +738,17 @@ services:
         - "${NATS_MONITORING_PORT}:6222"
         - "${NATS_ROUTE_PORT}:8222"
       networks:
+        - backend
+
+### Ollama ###############################################
+    ollama:
+      image: ollama/ollama:${OLLAMA_VERSION}
+      volumes:
+        - ollama:/root/.ollama
+      ports:
+        - "${OLLAMA_HOST_PORT}:11434"
+      networks:
+        - frontend
         - backend
 
 ### MongoDB ##############################################


### PR DESCRIPTION
## Description

Adds **Ollama** as a new laradock service. Ollama is a local LLM inference server that exposes an OpenAI-compatible HTTP API on port `11434`. It is added as an image-only service (`ollama/ollama`), following the existing `meilisearch` pattern, so no Dockerfile is required.

Changes (additive only, no existing service touched):
- `docker-compose.yml`: new `ollama` service block (image `ollama/ollama:${OLLAMA_VERSION}`, port `${OLLAMA_HOST_PORT}:11434`, named `ollama` volume at `/root/.ollama`, on the `frontend` and `backend` networks), plus the `ollama` named volume in the top-level `volumes:` block.
- `.env.example`: new `### OLLAMA` section with `OLLAMA_VERSION=latest` and `OLLAMA_HOST_PORT=11434`.

## Motivation and Context

PHP developers increasingly build AI features (chat, RAG, summarisation, structured extraction) and want to run them locally with no external API calls or per-token costs. Ollama gives them a local, OpenAI-compatible endpoint that libraries like Prism, Neuron AI, LLPhant, and openai-php can point at directly. It pairs naturally with the pgvector service already in laradock for fully local Retrieval-Augmented Generation. The named `ollama` volume keeps pulled models on disk across container restarts.

## Verification

Boot-tested with plain `docker run`, using the same image and volume the compose block uses (docker-compose is not needed for the test):

```
docker run -d --name laradock-ollama-boottest -p 21434:11434 \
  -v laradock-ollama-boottest-vol:/root/.ollama ollama/ollama:latest

curl http://localhost:21434/api/version
# -> {"version":"0.31.2"}

curl http://localhost:21434/
# -> Ollama is running
```

`docker compose config` also renders the `ollama` service and the `ollama` named volume correctly. No model was pulled, to keep the test light (the image is a multi-GB inference server). The `ollama/ollama` image is multi-arch, so it runs natively on both amd64 (CI) and arm64. The test container, volume, and temp files were cleaned up afterwards.

Note: the usage documentation section and the "Supported Services" table entry for Ollama are being handled separately, so this PR intentionally leaves the docs site and README table untouched and stays focused on the compose and env wiring.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] I've read the Contribution Guide.
- [x] I've updated the documentation. (Usage section and Supported Services table entry provided alongside this change; see the note above.)
- [x] I enjoyed my time contributing and making developer's life easier :)
