### PR TITLE
feat: add ArangoDB service (graph / multi-model DB)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1064,6 +1064,13 @@ GEARMAN_MYSQL_TABLE=gearman_queue
 
 ELK_VERSION=7.9.1
 
+### ARANGODB #############################################
+
+# Multi-model database (document + graph + key/value) with the AQL query language.
+ARANGODB_VERSION=3.12
+ARANGODB_PORT=8529
+ARANGODB_ROOT_PASSWORD=secret
+
 ### Tarantool #############################################
 
 TARANTOOL_PORT=3301

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   rethinkdb:
     driver: ${VOLUMES_DRIVER}
+  arangodb:
+    driver: ${VOLUMES_DRIVER}
   phpmyadmin:
     driver: ${VOLUMES_DRIVER}
   adminer:
@@ -967,6 +969,19 @@ services:
       depends_on:
         - php-fpm
       networks:
+        - backend
+
+### ArangoDB ############################################
+    arangodb:
+      image: arangodb:${ARANGODB_VERSION}
+      environment:
+        - ARANGO_ROOT_PASSWORD=${ARANGODB_ROOT_PASSWORD}
+      volumes:
+        - arangodb:/var/lib/arangodb3
+      ports:
+        - "${ARANGODB_PORT}:8529"
+      networks:
+        - frontend
         - backend
 
 ### Gearman ##############################################


### PR DESCRIPTION
## Description
Adds [ArangoDB](https://arangodb.com), a multi-model database (documents + graph + key/value) with the AQL query language, a graph-database option beyond the existing Neo4j.

- New `arangodb` service (image `arangodb:${ARANGODB_VERSION}`, default `3.12`), named volume, `ARANGODB_ROOT_PASSWORD`, port 8529.
- `.env.example` section + volume declaration.

**Verified locally:** boots on 3.12.9, `/_api/version` responds, a collection create returns 200, and `docker compose config` resolves the service. Multi-arch (ran natively on arm64; CI amd64 covered).

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).