### PR TITLE
feat: add SurrealDB service (graph / multi-model DB)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1069,6 +1069,14 @@ ELK_VERSION=7.9.1
 TARANTOOL_PORT=3301
 TARANTOOL_ADMIN_PORT=8002
 
+### SURREALDB ############################################
+
+# Multi-model database (document, graph, relational) with a SQL-like language.
+SURREALDB_VERSION=v2.6.5
+SURREALDB_PORT=8010
+SURREALDB_USER=root
+SURREALDB_PASSWORD=secret
+
 ### NATS ##################################################
 
 NATS_CLIENT_PORT=4222

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   aerospike:
     driver: ${VOLUMES_DRIVER}
+  surrealdb:
+    driver: ${VOLUMES_DRIVER}
   caddy:
     driver: ${VOLUMES_DRIVER}
   meilisearch:
@@ -1012,6 +1014,20 @@ services:
       depends_on:
         - beanstalkd
       networks:
+        - backend
+
+### SurrealDB ###########################################
+    surrealdb:
+      image: surrealdb/surrealdb:${SURREALDB_VERSION}
+      # Run as root so the server can create its RocksDB store in the named volume.
+      user: root
+      command: start --user ${SURREALDB_USER} --pass ${SURREALDB_PASSWORD} --bind 0.0.0.0:8000 rocksdb:/data/database.db
+      volumes:
+        - surrealdb:/data
+      ports:
+        - "${SURREALDB_PORT}:8000"
+      networks:
+        - frontend
         - backend
 
 ### Caddy Server #########################################


### PR DESCRIPTION
## Description
Adds [SurrealDB](https://surrealdb.com), a multi-model database (document, graph, and relational) with a SQL-like query language and a REST/WebSocket API, reachable from PHP over HTTP.

- New `surrealdb` service (image `surrealdb/surrealdb:${SURREALDB_VERSION}`, default `v2.6.5`), RocksDB file-backed named volume, root user + pass, port 8010.
- Runs as `user: root` so it can create its RocksDB store in the root-owned named volume (the image otherwise runs as a non-root user and fails with a permission error).
- `.env.example` section + volume declaration.

**Verified locally:** boots on `v2.6.5`, `/health` returns 200, `/version` reports `surrealdb-2.6.5`, and `docker compose config` resolves. Multi-arch (arm64 native; CI amd64 covered).

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).