### PR TITLE
feat: add LiteLLM service (LLM gateway/proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -929,6 +929,14 @@ TRAEFIK_DASHBOARD_USER='admin:$2y$10$lXaL3lj6raFic6rFqr2.lOBoCudAIhB6zyoqObNg290
 ACME_DOMAIN=example.org
 ACME_EMAIL=email@example.org
 
+### LITELLM ##############################################
+
+# LLM gateway/proxy: one OpenAI-compatible endpoint routing to any provider.
+# Edit litellm/config.yaml to add models/providers.
+LITELLM_VERSION=main-latest
+LITELLM_HOST_PORT=4000
+LITELLM_MASTER_KEY=sk-laradock
+
 ### MOSQUITTO #############################################
 
 MOSQUITTO_PORT=9001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -764,6 +764,20 @@ services:
       networks:
         - backend
 
+### LiteLLM ##############################################
+    litellm:
+      image: ghcr.io/berriai/litellm:${LITELLM_VERSION}
+      command: ["--config", "/app/config.yaml", "--port", "4000"]
+      volumes:
+        - ./litellm/config.yaml:/app/config.yaml
+      environment:
+        - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
+      ports:
+        - "${LITELLM_HOST_PORT}:4000"
+      networks:
+        - frontend
+        - backend
+
 ### ClickHouse ###########################################
     clickhouse:
       build:

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,0 +1,17 @@
+# Minimal LiteLLM proxy config. Add your own providers/models here.
+# Docs: https://docs.litellm.ai/docs/proxy/configs
+model_list:
+  # Example: route "local-llama" to the laradock Ollama service.
+  # Uncomment and adjust once Ollama has a model pulled.
+  # - model_name: local-llama
+  #   litellm_params:
+  #     model: ollama/llama3.2
+  #     api_base: http://ollama:11434
+  - model_name: mock-gpt
+    litellm_params:
+      model: openai/mock-gpt
+      api_base: http://localhost:4000
+      api_key: sk-mock
+
+litellm_settings:
+  drop_params: true


### PR DESCRIPTION
## Description
Adds [LiteLLM](https://litellm.ai), an LLM proxy/gateway that exposes **one OpenAI-compatible endpoint** routing to any provider (OpenAI, Anthropic, local Ollama, etc.). It's the backbone of agentic PHP apps needing a unified LLM API and key management, and pairs with the new Ollama service for fully local routing.

- New `litellm` service (image `ghcr.io/berriai/litellm:${LITELLM_VERSION}`, default `main-latest`), port 4000, `LITELLM_MASTER_KEY`.
- Ships `litellm/config.yaml` (mounted to `/app/config.yaml`) with a commented example wiring it to the laradock `ollama` service.
- `.env.example` section.

**Verified locally:** boots on `main-latest`, `/health/liveliness` returns 200 `"I'm alive!"`, and `docker compose config` resolves.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).