### PR TITLE
feat: add Valkey, Dragonfly and OpenSearch services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -452,6 +452,12 @@ CLICKHOUSE_HOST_LOG_PATH=./logs/clickhouse
 REDIS_PORT=6379
 REDIS_PASSWORD=secret_redis
 
+### VALKEY ###############################################
+
+# Redis-compatible fork (post-2024 Redis license change).
+VALKEY_VERSION=8-alpine
+VALKEY_PORT=6380
+
 ### REDIS CLUSTER #########################################
 
 REDIS_CLUSTER_PORT_RANGE=7000-7005
@@ -548,6 +554,13 @@ TYPESENSE_VERSION=30.2
 TYPESENSE_HOST_PORT=8108
 TYPESENSE_API_KEY=typesense
 TYPESENSE_ENABLE_CORS=true
+
+### OPENSEARCH ###########################################
+
+# Open-source fork of Elasticsearch (Apache 2.0).
+OPENSEARCH_VERSION=2
+OPENSEARCH_HOST_PORT=9202
+OPENSEARCH_MONITORING_PORT=9600
 
 ### ELASTICSEARCH #########################################
 
@@ -859,6 +872,12 @@ GITLAB_REGISTER_NON_INTERACTIVE=true
 ### NETDATA ###############################################
 
 NETDATA_PORT=19999
+
+### DRAGONFLY ############################################
+
+# Redis/Memcached-compatible, high-throughput in-memory store.
+DRAGONFLY_VERSION=latest
+DRAGONFLY_PORT=6381
 
 ### REDIS WEBUI ###########################################
 

--- a/DOCUMENTATION/docs/usage.md
+++ b/DOCUMENTATION/docs/usage.md
@@ -1449,6 +1449,42 @@ Varnish sits behind NGINX as a caching reverse proxy. NGINX listens on 80/443, f
 2. Web UI on `http://localhost:9091` (health `/-/healthy`). Edit `prometheus/prometheus.yml` to add scrape targets, then restart.
 
 
+<a name="Use-Valkey"></a>
+### Valkey
+
+[Valkey](https://valkey.io) is the community fork of Redis (created after the 2024 licence change) and is fully Redis-compatible. Point any Redis client at it.
+
+1. Start the container:
+   ```bash
+   docker-compose up -d valkey
+   ```
+2. Reachable on `${VALKEY_PORT}` (default `6380`) from the host, `valkey:6379` from other containers.
+
+
+<a name="Use-Dragonfly"></a>
+### Dragonfly
+
+[Dragonfly](https://www.dragonflydb.io) is a modern, high-throughput in-memory store that is wire-compatible with Redis and Memcached.
+
+1. Start the container:
+   ```bash
+   docker-compose up -d dragonfly
+   ```
+2. Reachable on `${DRAGONFLY_PORT}` (default `6381`) from the host, `dragonfly:6379` from other containers. Uses any Redis client.
+
+
+<a name="Use-OpenSearch"></a>
+### OpenSearch
+
+[OpenSearch](https://opensearch.org) is the Apache-2.0 open-source fork of Elasticsearch (search + analytics). This dev setup runs a single node with the security plugin disabled.
+
+1. Start the container:
+   ```bash
+   docker-compose up -d opensearch
+   ```
+2. REST API on `http://localhost:9202` (`OPENSEARCH_HOST_PORT`); `curl http://localhost:9202` returns the version. From other containers use `http://opensearch:9200`.
+
+
 <a name="Use-Beanstalkd"></a>
 ### Beanstalkd
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Laradock runs each service in its own container, which you turn on or off as nee
 | **PHP Compilers**         | PHP FPM, HHVM, RoadRunner                                                |
 | **Database Management Systems** | MySQL, PostgreSQL (PostGIS), pgvector, MariaDB, Percona, MSSQL, MongoDB, Neo4j, CouchDB, RethinkDB, Cassandra, ClickHouse, Tarantool |
 | **Database Management Tools** | PhpMyAdmin, Adminer, PgAdmin, MongoDB Web UI, Tarantool Admin, pgbackups (PostgreSQL) |
-| **Cache Engines**         | Redis, Redis Web UI, Redis Cluster, Memcached, Aerospike, Varnish, SSDB        |
+| **Cache Engines**         | Redis, Redis Web UI, Redis Cluster, Valkey, Dragonfly, Memcached, Aerospike, Varnish, SSDB        |
 | **Message Brokers**       | RabbitMQ, RabbitMQ Admin Console, Beanstalkd, Beanstalkd Admin Console, Eclipse Mosquitto, Gearman, NATS, Apache Kafka, Kafka Manager |
 | **Log Management**        | GrayLog, Kibana, LogStash                                                |
-| **Search Engines**        | ElasticSearch, Apache Solr, Manticore Search, Typesense, Dejavu          |
+| **Search Engines**        | ElasticSearch, OpenSearch, Apache Solr, Manticore Search, Typesense, Dejavu          |
 | **Vector Databases**      | pgvector, Qdrant, Weaviate, Chroma                                       |
 | **Graph / Multi-model Databases** | Neo4j, ArangoDB, SurrealDB                                       |
 | **Time-series Databases** | InfluxDB                                                                 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -913,6 +913,16 @@ services:
       networks:
         - backend
 
+### Valkey ##############################################
+    valkey:
+      image: valkey/valkey:${VALKEY_VERSION}
+      volumes:
+        - ${DATA_PATH_HOST}/valkey:/data
+      ports:
+        - "${VALKEY_PORT}:6379"
+      networks:
+        - backend
+
 ### Redis Cluster ########################################
     redis-cluster:
       restart: always
@@ -933,6 +943,18 @@ services:
         - N8N_SECURE_COOKIE=false
       networks:
         - frontend
+        - backend
+
+### Dragonfly ###########################################
+    dragonfly:
+      image: docker.dragonflydb.io/dragonflydb/dragonfly:${DRAGONFLY_VERSION}
+      ulimits:
+        memlock: -1
+      volumes:
+        - ${DATA_PATH_HOST}/dragonfly:/data
+      ports:
+        - "${DRAGONFLY_PORT}:6379"
+      networks:
         - backend
 
 ### SSDB #################################################
@@ -1346,6 +1368,30 @@ services:
         - TYPESENSE_DATA_DIR=/data
         - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
         - TYPESENSE_ENABLE_CORS=${TYPESENSE_ENABLE_CORS}
+      networks:
+        - frontend
+        - backend
+
+### OpenSearch ##########################################
+    opensearch:
+      image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
+      environment:
+        - discovery.type=single-node
+        - DISABLE_SECURITY_PLUGIN=true
+        - bootstrap.memory_lock=true
+        - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536
+          hard: 65536
+      volumes:
+        - ${DATA_PATH_HOST}/opensearch:/usr/share/opensearch/data
+      ports:
+        - "${OPENSEARCH_HOST_PORT}:9200"
+        - "${OPENSEARCH_MONITORING_PORT}:9600"
       networks:
         - frontend
         - backend


### PR DESCRIPTION
## Description
Fills the remaining service gaps versus Laravel Sail / DDEV / Warden, ahead of v18:

- **Valkey** (`valkey/valkey`, port 6380) - the community Redis fork after the 2024 licence change; Redis-compatible. (Sail, DDEV ship it.)
- **Dragonfly** (`dragonflydb/dragonfly`, port 6381) - high-throughput Redis/Memcached-compatible in-memory store.
- **OpenSearch** (`opensearchproject/opensearch`, port 9202) - the Apache-2.0 open-source fork of Elasticsearch, single-node dev config with the security plugin disabled. (DDEV, Warden ship it.)

All image-only and additive, on their own host ports so they coexist with the existing `redis` / `elasticsearch` services. `.env.example`, `usage.md`, and the Supported Services table (Intro.md + README.md, kept in sync) updated.

**Verified locally:** Valkey `PING`+`SET/GET`, Dragonfly `SET/GET`, OpenSearch `2.19.6` returns its version over REST. `docker compose config` renders all three.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality).