### PR TITLE
docs: add 'Local AI, built in' feature bullet

### DIFF
--- a/DOCUMENTATION/docs/Intro.md
+++ b/DOCUMENTATION/docs/Intro.md
@@ -29,6 +29,7 @@ Laradock is free, open-source under the MIT license, and has been battle-tested 
 - **70+ Ready-made Services**: Databases, caches, queues, search engines, and more, all pre-configured and waiting.
 - **All-in-One Dev Shell**: Run Artisan, Composer, Node, and every CLI your project needs inside the ready-made `workspace` container, with nothing installed on your host.
 - **Pick Your Database**: MySQL, PostgreSQL, MariaDB, MongoDB, Redis, and many others, ready to switch on.
+- **Local AI, Built In**: Run LLMs and vector search on your own machine with Ollama, LocalAI, LiteLLM, pgvector, Qdrant, Weaviate, and Chroma. Build AI and RAG features with no API keys and no cloud bills.
 - **Toggle Services On Demand**: Start only what a project needs with `docker compose up`, and stop them easily.
 - **One Environment Everywhere**: Identical setup on Linux, macOS, and Windows, so your team shares the same stack.
 - **A Container Per Service**: Every service is isolated, so nothing conflicts and each piece is easy to manage.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Laradock provides the PHP runtime, web server, databases, and background service
 
 - **Pre-configured stack:** 70+ ready-to-use containers (Nginx, Apache, Caddy, PHP-FPM, MySQL, PostgreSQL, MariaDB, MongoDB, Redis, Memcached, Elasticsearch, RabbitMQ, Beanstalkd, and more).
 - **All-in-one dev shell:** run Artisan, Composer, Node, and every CLI your project needs inside the ready-made `workspace` container, with nothing installed on your host.
+- **Local AI, built in:** run LLMs and vector search on your own machine (Ollama, LocalAI, LiteLLM, pgvector, Qdrant, Weaviate, Chroma) for AI/RAG features with no API keys or cloud bills.
 - **Easy version switching:** change PHP (5.6–8.5), database, or service versions in one place.
 - **Project-agnostic:** works with Laravel, Symfony, WordPress, Drupal, Magento, or vanilla PHP.
 - **Cross-platform:** the same environment on Linux, macOS, and Windows.


### PR DESCRIPTION
Surfaces the v18 AI stack (Ollama, LocalAI, LiteLLM, pgvector, Qdrant, Weaviate, Chroma) in the Features list (docs site + README), since local AI/RAG with no API keys is the headline capability of the release.

## Types of Changes
- [x] Documentation.